### PR TITLE
Refine Russian localization and migrate all locales to MiniMessage formatting

### DIFF
--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -4,56 +4,55 @@ warp:
     description: Teleportovat se na warp ceduli hráče
     parameters: "<player name>"
 warps:
-  deactivate: "&c Stará warp cedule deaktivována!"
+  deactivate: <red>Stará warp cedule deaktivována!</red>
   error:
-    does-not-exist: "&c Sakra! Tento warp již neexistuje!"
-    no-permission: "&c Na toto nemáš oprávnění!"
-    no-remove: "&c Nemůžeš odstranit tuto ceduli!"
-    no-warps-yet: "&c Nejsou k dispozici žádné warpy"
-    not-enough-level: "&c Úroveň tvého ostrova není dostatečně vysoká!"
-    not-on-island: "&c K tomuto musíš být na svém ostrově!"
-    not-safe: "&c Tento warp není bezpečný!"
-    your-level-is: "&c Úroveň tvého ostrova je jen [level], musí být vyšší než [required].
-      Spusť příkaz pro úroveň."
-    not-correct-rank: "&c Nemáte správnou hodnost pro nastavení warpu!"
+    does-not-exist: <red>Sakra! Tento warp již neexistuje!</red>
+    no-permission: <red>Na toto nemáš oprávnění!</red>
+    no-remove: <red>Nemůžeš odstranit tuto ceduli!</red>
+    no-warps-yet: <red>Nejsou k dispozici žádné warpy</red>
+    not-enough-level: <red>Úroveň tvého ostrova není dostatečně vysoká!</red>
+    not-on-island: <red>K tomuto musíš být na svém ostrově!</red>
+    not-safe: <red>Tento warp není bezpečný!</red>
+    your-level-is: <red>Úroveň tvého ostrova je jen [level], musí být vyšší než [required]. Spusť příkaz pro úroveň.</red>
+    not-correct-rank: <red>Nemáte správnou hodnost pro nastavení warpu!</red>
   help:
     description: otevřít panel warpů
-  player-warped: "&2 [name] se pokřivilo na váš [gamemode] warp znamení!"
-  sign-removed: "&c Warp cedule odstraněna!"
-  success: "&a Úspěch!"
-  warpTip: "&6 Polož warp ceduli s [text] na vrchu"
-  warpToPlayersSign: "&6 Teleportuji tě na ceduli [player]"
+  player-warped: <dark_green>[name] se pokřivilo na váš [gamemode] warp znamení!</dark_green>
+  sign-removed: <red>Warp cedule odstraněna!</red>
+  success: <green>Úspěch!</green>
+  warpTip: <gold>Polož warp ceduli s [text] na vrchu</gold>
+  warpToPlayersSign: <gold>Teleportuji tě na ceduli [player]</gold>
   gui:
     titles:
-      warp-title: "&0&l Warp Signs"
+      warp-title: <black><bold>Warp Signs</bold></black>
     buttons:
       previous:
-        name: "&f&l Předchozí stránka"
-        description: "&7 Přepnout na stránku [number]"
+        name: <white><bold>Předchozí stránka</bold></white>
+        description: <gray>Přepnout na stránku [number]</gray>
       next:
-        name: "&f&l Další stránka"
-        description: "&7 Přepnout na stránku [number]"
+        name: <white><bold>Další stránka</bold></white>
+        description: <gray>Přepnout na stránku [number]</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l Náhodné pokřivení"
-        description: "&7 Hmm, kde se objevím?"
+        name: <white><bold>Náhodné pokřivení</bold></white>
+        description: <gray>Hmm, kde se objevím?</gray>
     tips:
-      click-to-previous: "&e Klepnutím na &7 zobrazíte předchozí stránku."
-      click-to-next: "&e Klepnutím na &7 zobrazíte další stránku."
-      click-to-warp: "&e Klikněte na &7 pro deformaci."
+      click-to-previous: <yellow>Klepnutím na </yellow><gray>zobrazíte předchozí stránku.</gray>
+      click-to-next: <yellow>Klepnutím na </yellow><gray>zobrazíte další stránku.</gray>
+      click-to-warp: <yellow>Klikněte na </yellow><gray>pro deformaci.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: přepnout znak warp
-  enabled: "&a Vaše warp je nyní viditelný!"
-  disabled: "&c Váš warp je nyní skrytý!"
+  enabled: <green>Vaše warp je nyní viditelný!</green>
+  disabled: <red>Váš warp je nyní skrytý!</red>
   error:
-    no-permission: "&c K tomu nemáte oprávnění!"
-    generic: "&c Při přepínání vašeho warpu došlo k chybě."
-    no-warp: "&c Nemáte warp k přepínání!"
+    no-permission: <red>K tomu nemáte oprávnění!</red>
+    generic: <red>Při přepínání vašeho warpu došlo k chybě.</red>
+    no-warp: <red>Nemáte warp k přepínání!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -4,56 +4,55 @@ warp:
     description: Warpt dich zu dem Warp Schild von dem Spieler
     parameters: "<player name>"
 warps:
-  deactivate: "&c Altes Warp Schild deaktiviert!"
+  deactivate: <red>Altes Warp Schild deaktiviert!</red>
   error:
-    does-not-exist: "&c Oh nein! Dieser Warp existiert nicht mehr!"
-    no-permission: "&c Hierfür hast du keine Rechte!"
-    no-remove: "&c Du kannst dieses Schild nicht entfernen!"
-    no-warps-yet: "&c Es sind noch keine Warps verfügbar"
-    not-enough-level: "&c Dein Insel-Level ist nicht hoch gneug!"
-    not-on-island: "&c Dafür musst du auf deiner Insel sein!"
-    not-safe: "&c Dieser Warp ist nicht sicher!"
-    your-level-is: "&c Dein Insel-Level ist erst [level] und muss höher als [required]
-      sein. Nutze das Level Kommando."
-    not-correct-rank: "&c Sie haben nicht den richtigen Rang, um einen Warp einzustellen!"
+    does-not-exist: <red>Oh nein! Dieser Warp existiert nicht mehr!</red>
+    no-permission: <red>Hierfür hast du keine Rechte!</red>
+    no-remove: <red>Du kannst dieses Schild nicht entfernen!</red>
+    no-warps-yet: <red>Es sind noch keine Warps verfügbar</red>
+    not-enough-level: <red>Dein Insel-Level ist nicht hoch gneug!</red>
+    not-on-island: <red>Dafür musst du auf deiner Insel sein!</red>
+    not-safe: <red>Dieser Warp ist nicht sicher!</red>
+    your-level-is: <red>Dein Insel-Level ist erst [level] und muss höher als [required] sein. Nutze das Level Kommando.</red>
+    not-correct-rank: <red>Sie haben nicht den richtigen Rang, um einen Warp einzustellen!</red>
   help:
     description: Öffnet das Warps Panel
-  player-warped: "&2 [name] ist zu deinem [gamemode]-Warp-Zeichen gesprungen!"
-  sign-removed: "&c Warp Schild entfernt!"
-  success: "&a Erfolg!"
-  warpTip: "&6 Platziere ein Warp Schild mit [text] in der ersten Zeile"
-  warpToPlayersSign: "&6 Warpe zu [player]'s Schild"
+  player-warped: <dark_green>[name] ist zu deinem [gamemode]-Warp-Zeichen gesprungen!</dark_green>
+  sign-removed: <red>Warp Schild entfernt!</red>
+  success: <green>Erfolg!</green>
+  warpTip: <gold>Platziere ein Warp Schild mit [text] in der ersten Zeile</gold>
+  warpToPlayersSign: <gold>Warpe zu [player]'s Schild</gold>
   gui:
     titles:
-      warp-title: "&0&l Warp-Schild"
+      warp-title: <black><bold>Warp-Schild</bold></black>
     buttons:
       previous:
-        name: "&f&l Vorherige Seite"
-        description: "&7 Zur Seite [number] wechseln"
+        name: <white><bold>Vorherige Seite</bold></white>
+        description: <gray>Zur Seite [number] wechseln</gray>
       next:
-        name: "&f&l Nächste Seite"
-        description: "&7 Zur Seite [number] wechseln"
+        name: <white><bold>Nächste Seite</bold></white>
+        description: <gray>Zur Seite [number] wechseln</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l Random Warp"
-        description: "&7 Hmm, wo werde ich erscheinen?"
+        name: <white><bold>Random Warp</bold></white>
+        description: <gray>Hmm, wo werde ich erscheinen?</gray>
     tips:
-      click-to-previous: "&e Klicken &7, um die vorherige Seite anzuzeigen."
-      click-to-next: "&e Klicken &7, um die nächste Seite anzuzeigen."
-      click-to-warp: "&e Zum Warpen &7 klicken."
+      click-to-previous: <yellow>Klicken </yellow><gray>, um die vorherige Seite anzuzeigen.</gray>
+      click-to-next: <yellow>Klicken </yellow><gray>, um die nächste Seite anzuzeigen.</gray>
+      click-to-warp: <yellow>Zum Warpen </yellow><gray>klicken.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: das Warp-Zeichen umschalten
-  enabled: "&a Ihr Warp ist jetzt sichtbar!"
-  disabled: "&c Ihr Warp ist jetzt verborgen!"
+  enabled: <green>Ihr Warp ist jetzt sichtbar!</green>
+  disabled: <red>Ihr Warp ist jetzt verborgen!</red>
   error:
-    no-permission: "&c Sie haben keine Berechtigung, das zu tun!"
-    generic: "&c Beim Umschalten Ihres Warps ist ein Fehler aufgetreten."
-    no-warp: "&c Sie haben keinen Warp zum Umschalten!"
+    no-permission: <red>Sie haben keine Berechtigung, das zu tun!</red>
+    generic: <red>Beim Umschalten Ihres Warps ist ein Fehler aufgetreten.</red>
+    no-warp: <red>Sie haben keinen Warp zum Umschalten!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -8,67 +8,67 @@ warp:
     description: "warp to the player's warp sign"
     parameters: <player name>
 warps: 
-  deactivate: "&c Old warp sign deactivated!"
+  deactivate: <red>Old warp sign deactivated!</red>
   error: 
-    does-not-exist: "&c Oh snap! That warp no longer exists!"
-    no-permission: "&c You do not have permission to do that!"
-    no-remove: "&c You cannot remove that sign!"
-    no-warps-yet: "&c There are no warps available yet"
-    not-enough-level: "&c Your island level is not high enough!"
-    not-on-island: "&c You must be on your island to do that!"
-    not-safe: "&c That warp is not safe!"
-    your-level-is: "&c Your island level is only [level] and must be higher than [required]. Run the level command."
-    not-correct-rank: "&c You do not have the correct rank to set a warp!"
+    does-not-exist: <red>Oh snap! That warp no longer exists!</red>
+    no-permission: <red>You do not have permission to do that!</red>
+    no-remove: <red>You cannot remove that sign!</red>
+    no-warps-yet: <red>There are no warps available yet</red>
+    not-enough-level: <red>Your island level is not high enough!</red>
+    not-on-island: <red>You must be on your island to do that!</red>
+    not-safe: <red>That warp is not safe!</red>
+    your-level-is: <red>Your island level is only [level] and must be higher than [required]. Run the level command.</red>
+    not-correct-rank: <red>You do not have the correct rank to set a warp!</red>
   help:
     description: "open the warps panel"
-  player-warped: "&2 [name] warped to your [gamemode] warp sign!"
-  sign-removed: "&c Warp sign removed!"
-  success: "&a Success!"
-  warpTip: "&6 Place a warp sign with [text] on the top"
-  warpToPlayersSign: "&6 Warping to [player]'s sign"
+  player-warped: <dark_green>[name] warped to your [gamemode] warp sign!</dark_green>
+  sign-removed: <red>Warp sign removed!</red>
+  success: <green>Success!</green>
+  warpTip: <gold>Place a warp sign with [text] on the top</gold>
+  warpToPlayersSign: <gold>Warping to [player]'s sign</gold>
 
   gui:
     titles:
       # The title of warp panel
-      warp-title: '&0&l Warp Signs'
+      warp-title: <black><bold>Warp Signs</bold></black>
     buttons:
       # Button that is used in multi-page GUIs which allows to return to previous page.
       previous:
-        name: "&f&l Previous Page"
+        name: <white><bold>Previous Page</bold></white>
         description: |-
-          &7 Switch to [number] page
+           <gray>Switch to [number] page</gray>
       # Button that is used in multi-page GUIs which allows to go to next page.
       next:
-        name: "&f&l Next Page"
+        name: <white><bold>Next Page</bold></white>
         description: |-
-          &7 Switch to [number] page
+           <gray>Switch to [number] page</gray>
       # Button for a warp
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: |-
-          [sign_text]
+           [sign_text]
       # Button for a random warp
       random:
-        name: "&f&l Random Warp"
+        name: <white><bold>Random Warp</bold></white>
         description: |-
-          &7 Hmm, where will I appear?
+           <gray>Hmm, where will I appear?</gray>
     tips:
-      click-to-previous: "&e Click &7 to view previous page."
-      click-to-next: "&e Click &7 to view next page."
-      click-to-warp: "&e Click &7 to warp."
+      click-to-previous: <yellow>Click </yellow><gray>to view previous page.</gray>
+      click-to-next: <yellow>Click </yellow><gray>to view next page.</gray>
+      click-to-warp: <yellow>Click </yellow><gray>to warp.</gray>
   conversations:
     # Prefix for messages that are send from server.
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 
 togglewarp:
   help:
     description: "toggle the warp sign"
-  enabled: "&a Your warp is now visible!"
-  disabled: "&c Your warp is now hidden!"
+  enabled: <green>Your warp is now visible!</green>
+  disabled: <red>Your warp is now hidden!</red>
   error:
-    no-permission: "&c You do not have permission to do that!"
-    generic: "&c An error occurred while toggling your warp."
-    no-warp: "&c You do not have a warp to toggle!"
+    no-permission: <red>You do not have permission to do that!</red>
+    generic: <red>An error occurred while toggling your warp.</red>
+    no-warp: <red>You do not have a warp to toggle!</red>
 
 protection:
   flags:

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -4,57 +4,55 @@ warp:
     description: Teletransportarte hacia el warp del jugador
     parameters: "<player name>"
 warps:
-  deactivate: "&c ¡Antiguo cartel de teletransportación desactivado!"
+  deactivate: <red>¡Antiguo cartel de teletransportación desactivado!</red>
   error:
-    does-not-exist: "&c ¡Oh, chasquido! ¡Ese teletransporte ya no existe!"
-    no-permission: "&c ¡No tienes permisos para hacer eso!"
-    no-remove: "&c ¡No puedes quitar ese cartel!"
-    no-warps-yet: "&c No hay teletransportes disponibles todavía"
-    not-enough-level: "&c ¡Tu nivel de isla no es lo suficientemente alto!"
-    not-on-island: "&c ¡Debes estar en tu isla para hacer eso!"
-    not-safe: "&c ¡Ese teletransporte no es seguro!"
-    your-level-is: "&c Tu nivel de isla es solo [level] y debe ser mayor que [required].
-      Ejecuta el comando de nivel."
-    not-correct-rank: "&c ¡No tienes el rango correcto para crear un teletransporte!"
+    does-not-exist: <red>¡Oh, chasquido! ¡Ese teletransporte ya no existe!</red>
+    no-permission: <red>¡No tienes permisos para hacer eso!</red>
+    no-remove: <red>¡No puedes quitar ese cartel!</red>
+    no-warps-yet: <red>No hay teletransportes disponibles todavía</red>
+    not-enough-level: <red>¡Tu nivel de isla no es lo suficientemente alto!</red>
+    not-on-island: <red>¡Debes estar en tu isla para hacer eso!</red>
+    not-safe: <red>¡Ese teletransporte no es seguro!</red>
+    your-level-is: <red>Tu nivel de isla es solo [level] y debe ser mayor que [required]. Ejecuta el comando de nivel.</red>
+    not-correct-rank: <red>¡No tienes el rango correcto para crear un teletransporte!</red>
   help:
     description: Abre el panel de warps
-  player-warped: "&2 [name] se ha teletransportado a tu cartel de teletransportación
-    de [gamemode]!"
-  sign-removed: "&c Cartel de teletransportación eliminado!"
-  success: "&a Éxito!"
-  warpTip: "&6 Coloca un cartel con [text] en la parte superior"
-  warpToPlayersSign: "&6 Teletransportandote al cartel del jugador [player]"
+  player-warped: <dark_green>[name] se ha teletransportado a tu cartel de teletransportación de [gamemode]!</dark_green>
+  sign-removed: <red>Cartel de teletransportación eliminado!</red>
+  success: <green>Éxito!</green>
+  warpTip: <gold>Coloca un cartel con [text] en la parte superior</gold>
+  warpToPlayersSign: <gold>Teletransportandote al cartel del jugador [player]</gold>
   gui:
     titles:
-      warp-title: "&0&l Carteles de Teletransporte"
+      warp-title: <black><bold>Carteles de Teletransporte</bold></black>
     buttons:
       previous:
-        name: "&f&l Página Anterior"
-        description: "&7 Ir a la página [number]"
+        name: <white><bold>Página Anterior</bold></white>
+        description: <gray>Ir a la página [number]</gray>
       next:
-        name: "&f&l Siguiente Página"
-        description: "&7 Ir a la página [number]"
+        name: <white><bold>Siguiente Página</bold></white>
+        description: <gray>Ir a la página [number]</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l Teletransporte aleatorio"
-        description: "&7 Hmm, ¿Dónde apareceré?"
+        name: <white><bold>Teletransporte aleatorio</bold></white>
+        description: <gray>Hmm, ¿Dónde apareceré?</gray>
     tips:
-      click-to-previous: "&e Clic &7 para ver la página anterior."
-      click-to-next: "&e Clic &7 para ver la página siguiente."
-      click-to-warp: "&e Clic &7 para teletransportarse."
+      click-to-previous: <yellow>Clic </yellow><gray>para ver la página anterior.</gray>
+      click-to-next: <yellow>Clic </yellow><gray>para ver la página siguiente.</gray>
+      click-to-warp: <yellow>Clic </yellow><gray>para teletransportarse.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: alternar el cartel de teletransporte
-  enabled: "&a ¡Tu teletransporte ahora es visible!"
-  disabled: "&c ¡Tu teletransporte ahora está oculto!"
+  enabled: <green>¡Tu teletransporte ahora es visible!</green>
+  disabled: <red>¡Tu teletransporte ahora está oculto!</red>
   error:
-    no-permission: "&c ¡No tienes permisos para hacer eso!"
-    generic: "&c Ocurrió un error al alternar tu teletransporte."
-    no-warp: "&c ¡No tienes un teletransporte para alternar!"
+    no-permission: <red>¡No tienes permisos para hacer eso!</red>
+    generic: <red>Ocurrió un error al alternar tu teletransporte.</red>
+    no-warp: <red>¡No tienes un teletransporte para alternar!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -4,57 +4,55 @@ warp:
     description: te téléporte au Warp d'un autre joueur
     parameters: "<pseudo>"
 warps:
-  deactivate: "&c Ancienne pancarte de warp désactivée !"
+  deactivate: <red>Ancienne pancarte de warp désactivée !</red>
   error:
-    does-not-exist: "&c Oh ! Cette téléportation n'existe plus !"
-    no-permission: "&c Vous n'avez pas le droit de faire cela !"
-    no-remove: "&c Vous ne pouvez pas enlever cette pancarte !"
-    no-warps-yet: "&c Il n'y a pas encore de téléportation disponible"
-    not-enough-level: "&c Le niveau de votre île n'est pas assez élevé !"
-    not-on-island: "&c Vous devez être sur votre île pour faire cela !"
-    not-safe: "&c Cette téléportation n'est pas sûre !"
-    your-level-is: "&c Le niveau de votre île n'est que [level] et doit être supérieur
-      à [required]. Exécutez la commande level."
-    not-correct-rank: "&c Vous n'avez pas le grade adéquat pour poser une chaîne !"
+    does-not-exist: <red>Oh ! Cette téléportation n'existe plus !</red>
+    no-permission: <red>Vous n'avez pas le droit de faire cela !</red>
+    no-remove: <red>Vous ne pouvez pas enlever cette pancarte !</red>
+    no-warps-yet: <red>Il n'y a pas encore de téléportation disponible</red>
+    not-enough-level: <red>Le niveau de votre île n'est pas assez élevé !</red>
+    not-on-island: <red>Vous devez être sur votre île pour faire cela !</red>
+    not-safe: <red>Cette téléportation n'est pas sûre !</red>
+    your-level-is: <red>Le niveau de votre île n'est que [level] et doit être supérieur à [required]. Exécutez la commande level.</red>
+    not-correct-rank: <red>Vous n'avez pas le grade adéquat pour poser une chaîne !</red>
   help:
     description: Ouvre le menu des Warps
-  player-warped: "&2 [name] s'est rendu à votre pancarte de téléportation [gamemode]
-    !"
-  sign-removed: "&c Panneau de téléportation enlevé !"
-  success: "&a Succès !"
-  warpTip: "&6 Placer une pancarte de téléportation avec [text] sur le dessus"
-  warpToPlayersSign: "&6 Téléportation a la pancarte de [player]"
+  player-warped: <dark_green>[name] s'est rendu à votre pancarte de téléportation [gamemode] !</dark_green>
+  sign-removed: <red>Panneau de téléportation enlevé !</red>
+  success: <green>Succès !</green>
+  warpTip: <gold>Placer une pancarte de téléportation avec [text] sur le dessus</gold>
+  warpToPlayersSign: <gold>Téléportation a la pancarte de [player]</gold>
   gui:
     titles:
-      warp-title: "&0&l Pancarte de téléportation"
+      warp-title: <black><bold>Pancarte de téléportation</bold></black>
     buttons:
       previous:
-        name: "&f&l Page précédente"
-        description: "&7 Aller à la page [numéro]."
+        name: <white><bold>Page précédente</bold></white>
+        description: <gray>Aller à la page [numéro].</gray>
       next:
-        name: "&f&l Page suivante"
-        description: "&7 Passer à la page [numéro]."
+        name: <white><bold>Page suivante</bold></white>
+        description: <gray>Passer à la page [numéro].</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l Téléportation aléatoire"
-        description: "&7 Hmm, où vais-je apparaître ?"
+        name: <white><bold>Téléportation aléatoire</bold></white>
+        description: <gray>Hmm, où vais-je apparaître ?</gray>
     tips:
-      click-to-previous: "&e Cliquez sur &7 pour afficher la page précédente."
-      click-to-next: "&e Cliquez sur &7 pour afficher la page suivante."
-      click-to-warp: "&e Cliquez sur &7 pour te téléporter."
+      click-to-previous: <yellow>Cliquez sur </yellow><gray>pour afficher la page précédente.</gray>
+      click-to-next: <yellow>Cliquez sur </yellow><gray>pour afficher la page suivante.</gray>
+      click-to-warp: <yellow>Cliquez sur </yellow><gray>pour te téléporter.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: basculer le signe de distorsion
-  enabled: "&a Votre chaîne est maintenant visible !"
-  disabled: "&c Votre chaîne est maintenant cachée !"
+  enabled: <green>Votre chaîne est maintenant visible !</green>
+  disabled: <red>Votre chaîne est maintenant cachée !</red>
   error:
-    no-permission: "&c Vous n'avez pas la permission de faire ça !"
-    generic: "&c Une erreur s'est produite lors du basculement de votre chaîne."
-    no-warp: "&c Vous n'avez pas de chaîne à activer !"
+    no-permission: <red>Vous n'avez pas la permission de faire ça !</red>
+    generic: <red>Une erreur s'est produite lors du basculement de votre chaîne.</red>
+    no-warp: <red>Vous n'avez pas de chaîne à activer !</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -4,56 +4,55 @@ warp:
     description: teleportirati se na warp znak igrača
     parameters: "<ime igrača>"
 warps:
-  deactivate: "&c Stari warp znak deaktiviran!"
+  deactivate: <red>Stari warp znak deaktiviran!</red>
   error:
-    does-not-exist: "&c Ups! Taj warp više ne postoji!"
-    no-permission: "&c Nemate dozvolu za to!"
-    no-remove: "&c Ne možete ukloniti taj znak!"
-    no-warps-yet: "&c Još nema dostupnih warpova"
-    not-enough-level: "&c Razina vašeg otoka nije dovoljno visoka!"
-    not-on-island: "&c Morate biti na svom otoku!"
-    not-safe: "&c Taj warp nije siguran!"
-    your-level-is: "&c Razina vašeg otoka je samo [level] i mora biti viša od [required].
-      Pokrenite naredbu razine."
-    not-correct-rank: "&c Nemate odgovarajući rang za postavljanje warpa!"
+    does-not-exist: <red>Ups! Taj warp više ne postoji!</red>
+    no-permission: <red>Nemate dozvolu za to!</red>
+    no-remove: <red>Ne možete ukloniti taj znak!</red>
+    no-warps-yet: <red>Još nema dostupnih warpova</red>
+    not-enough-level: <red>Razina vašeg otoka nije dovoljno visoka!</red>
+    not-on-island: <red>Morate biti na svom otoku!</red>
+    not-safe: <red>Taj warp nije siguran!</red>
+    your-level-is: <red>Razina vašeg otoka je samo [level] i mora biti viša od [required]. Pokrenite naredbu razine.</red>
+    not-correct-rank: <red>Nemate odgovarajući rang za postavljanje warpa!</red>
   help:
     description: otvori panel warpova
-  player-warped: "&2 [name] se teleportirao na vaš [gamemode] warp znak!"
-  sign-removed: "&c Warp znak uklonjen!"
-  success: "&a Uspjeh!"
-  warpTip: "&6 Postavi warp znak s [text] na vrhu"
-  warpToPlayersSign: "&6 Teleportiranje na znak igrača [player]"
+  player-warped: <dark_green>[name] se teleportirao na vaš [gamemode] warp znak!</dark_green>
+  sign-removed: <red>Warp znak uklonjen!</red>
+  success: <green>Uspjeh!</green>
+  warpTip: <gold>Postavi warp znak s [text] na vrhu</gold>
+  warpToPlayersSign: <gold>Teleportiranje na znak igrača [player]</gold>
   gui:
     titles:
-      warp-title: "&0&l Warp Znakovi"
+      warp-title: <black><bold>Warp Znakovi</bold></black>
     buttons:
       previous:
-        name: "&f&l Prethodna stranica"
-        description: "&7 Prebaci na stranicu [number]"
+        name: <white><bold>Prethodna stranica</bold></white>
+        description: <gray>Prebaci na stranicu [number]</gray>
       next:
-        name: "&f&l Sljedeća stranica"
-        description: "&7 Prebaci na stranicu [number]"
+        name: <white><bold>Sljedeća stranica</bold></white>
+        description: <gray>Prebaci na stranicu [number]</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l Nasumični Warp"
-        description: "&7 Hmm, gdje ću se pojaviti?"
+        name: <white><bold>Nasumični Warp</bold></white>
+        description: <gray>Hmm, gdje ću se pojaviti?</gray>
     tips:
-      click-to-previous: "&e Kliknite &7 za prikaz prethodne stranice."
-      click-to-next: "&e Kliknite &7 za prikaz sljedeće stranice."
-      click-to-warp: "&e Kliknite &7 za teleportaciju."
+      click-to-previous: <yellow>Kliknite </yellow><gray>za prikaz prethodne stranice.</gray>
+      click-to-next: <yellow>Kliknite </yellow><gray>za prikaz sljedeće stranice.</gray>
+      click-to-warp: <yellow>Kliknite </yellow><gray>za teleportaciju.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: prebaci warp znak
-  enabled: "&a Vaš warp je sada vidljiv!"
-  disabled: "&c Vaš warp je sada skriven!"
+  enabled: <green>Vaš warp je sada vidljiv!</green>
+  disabled: <red>Vaš warp je sada skriven!</red>
   error:
-    no-permission: "&c Nemate dozvolu za to!"
-    generic: "&c Dogodila se greška pri prebacivanju vašeg warpa."
-    no-warp: "&c Nemate warp za prebacivanje!"
+    no-permission: <red>Nemate dozvolu za to!</red>
+    generic: <red>Dogodila se greška pri prebacivanju vašeg warpa.</red>
+    no-warp: <red>Nemate warp za prebacivanje!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -4,56 +4,55 @@ warp:
     description: Teleportálás a játékos teleport táblájához
     parameters: "<játékosnév>"
 warps:
-  deactivate: "&c Régi teleport tábla deaktiválva!"
+  deactivate: <red>Régi teleport tábla deaktiválva!</red>
   error:
-    does-not-exist: "&c Ajjaj! Ez a teleport nem létezik!"
-    no-permission: "&c Nincs jogod ehhez!"
-    no-remove: "&c Nem törölheted ezt a táblát!"
-    no-warps-yet: "&c Jelenleg nem érhetőek el teleportok"
-    not-enough-level: "&c A szigeted szintje nem elég magas!"
-    not-on-island: "&c Ehhez szigeten kell lenned!"
-    not-safe: "&c Ez a teleport nem biztonságos!"
-    your-level-is: "&c Jelenleg a sziget szinted [level], és nagyobbnak kell lennie,
-      mint [required]. Futtasd a szint parancsot."
-    not-correct-rank: "&c Nincs megfelelő rangod a warp beállításához!"
+    does-not-exist: <red>Ajjaj! Ez a teleport nem létezik!</red>
+    no-permission: <red>Nincs jogod ehhez!</red>
+    no-remove: <red>Nem törölheted ezt a táblát!</red>
+    no-warps-yet: <red>Jelenleg nem érhetőek el teleportok</red>
+    not-enough-level: <red>A szigeted szintje nem elég magas!</red>
+    not-on-island: <red>Ehhez szigeten kell lenned!</red>
+    not-safe: <red>Ez a teleport nem biztonságos!</red>
+    your-level-is: <red>Jelenleg a sziget szinted [level], és nagyobbnak kell lennie, mint [required]. Futtasd a szint parancsot.</red>
+    not-correct-rank: <red>Nincs megfelelő rangod a warp beállításához!</red>
   help:
     description: Teleportok panel megnyitása
-  player-warped: "&2 [name] teleportált a [gamemode] teleport tábládhoz!"
-  sign-removed: "&c Teleport tábla törölve!"
-  success: "&a Sikeres!"
-  warpTip: "&6 Helyezz le egy teleport táblát a következő szöveggel [text] a tetején"
-  warpToPlayersSign: "&6 Teleportálás [player] táblájához"
+  player-warped: <dark_green>[name] teleportált a [gamemode] teleport tábládhoz!</dark_green>
+  sign-removed: <red>Teleport tábla törölve!</red>
+  success: <green>Sikeres!</green>
+  warpTip: <gold>Helyezz le egy teleport táblát a következő szöveggel [text] a tetején</gold>
+  warpToPlayersSign: <gold>Teleportálás [player] táblájához</gold>
   gui:
     titles:
-      warp-title: "&0&l Teleport Táblák"
+      warp-title: <black><bold>Teleport Táblák</bold></black>
     buttons:
       previous:
-        name: "&f&l Előző oldal"
-        description: "&7 Ugrás a(z) [number]. oldalra"
+        name: <white><bold>Előző oldal</bold></white>
+        description: <gray>Ugrás a(z) [number]. oldalra</gray>
       next:
-        name: "&f&l Következő oldal"
-        description: "&7 Ugrás a(z) [number]. oldalra"
+        name: <white><bold>Következő oldal</bold></white>
+        description: <gray>Ugrás a(z) [number]. oldalra</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l Véletlenszerű Teleport"
-        description: "&7 Hmm, hol fogok megjelenni?"
+        name: <white><bold>Véletlenszerű Teleport</bold></white>
+        description: <gray>Hmm, hol fogok megjelenni?</gray>
     tips:
-      click-to-previous: "&e Kattintson &7 az előző oldal megtekintéséhez."
-      click-to-next: "&e Kattintson &7 a következő oldal megtekintéséhez."
-      click-to-warp: "&e Kattintson &7 a teleportáláshoz."
+      click-to-previous: <yellow>Kattintson </yellow><gray>az előző oldal megtekintéséhez.</gray>
+      click-to-next: <yellow>Kattintson </yellow><gray>a következő oldal megtekintéséhez.</gray>
+      click-to-warp: <yellow>Kattintson </yellow><gray>a teleportáláshoz.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: warp jel átváltása
-  enabled: "&a A warped most látható!"
-  disabled: "&c A warped most rejtett!"
+  enabled: <green>A warped most látható!</green>
+  disabled: <red>A warped most rejtett!</red>
   error:
-    no-permission: "&c Nincs jogod ehhez!"
-    generic: "&c Hiba történt a warp átváltása közben."
-    no-warp: "&c Nincs warpod amit átválthatnál!"
+    no-permission: <red>Nincs jogod ehhez!</red>
+    generic: <red>Hiba történt a warp átváltása közben.</red>
+    no-warp: <red>Nincs warpod amit átválthatnál!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -4,56 +4,55 @@ warp:
     description: warp ke tanda warp pemain
     parameters: "<player name>"
 warps:
-  deactivate: "&c Tanda warp lama dinonaktifkan!"
+  deactivate: <red>Tanda warp lama dinonaktifkan!</red>
   error:
-    does-not-exist: "&c Oh! Warp itu tidak ada lagi!"
-    no-permission: "&c Kamu tidak punya izin untuk melakukan itu!"
-    no-remove: "&c Kamu tidak bisa menghapus tanda itu!"
-    no-warps-yet: "&c Belum ada warps yang tersedia"
-    not-enough-level: "&c Level pulaumu tidak cukup tinggi!"
-    not-on-island: "&c Kamu harus berada di pulaumu untuk melakukan itu!"
-    not-safe: "&c Warp itu tidak aman!"
-    your-level-is: "&c Level pulau Anda hanya [level] dan harus lebih tinggi dari
-      [required]. Jalankan perintah level."
-    not-correct-rank: "&c Kamu tidak punya rank yang benar untuk mengatur warp!"
+    does-not-exist: <red>Oh! Warp itu tidak ada lagi!</red>
+    no-permission: <red>Kamu tidak punya izin untuk melakukan itu!</red>
+    no-remove: <red>Kamu tidak bisa menghapus tanda itu!</red>
+    no-warps-yet: <red>Belum ada warps yang tersedia</red>
+    not-enough-level: <red>Level pulaumu tidak cukup tinggi!</red>
+    not-on-island: <red>Kamu harus berada di pulaumu untuk melakukan itu!</red>
+    not-safe: <red>Warp itu tidak aman!</red>
+    your-level-is: <red>Level pulau Anda hanya [level] dan harus lebih tinggi dari [required]. Jalankan perintah level.</red>
+    not-correct-rank: <red>Kamu tidak punya rank yang benar untuk mengatur warp!</red>
   help:
     description: buka panel warps
-  player-warped: "&2 [name] nge-warp ke tanda warp [gamemode] kamu!"
-  sign-removed: "&c Tanda warp dihilangkan!"
-  success: "&a Sukses!"
-  warpTip: "&6 Tempatkan tanda warp dengan [text] di atas\n"
-  warpToPlayersSign: "&6 Pergi ke tanda [player]"
+  player-warped: <dark_green>[name] nge-warp ke tanda warp [gamemode] kamu!</dark_green>
+  sign-removed: <red>Tanda warp dihilangkan!</red>
+  success: <green>Sukses!</green>
+  warpTip: <gold>Tempatkan tanda warp dengan [text] di atas</gold>
+  warpToPlayersSign: <gold>Pergi ke tanda [player]</gold>
   gui:
     titles:
-      warp-title: "&0&l Tanda Warp"
+      warp-title: <black><bold>Tanda Warp</bold></black>
     buttons:
       previous:
-        name: "&f&l Halaman Sebelumnya"
-        description: "&7 Beralih ke halaman [number]"
+        name: <white><bold>Halaman Sebelumnya</bold></white>
+        description: <gray>Beralih ke halaman [number]</gray>
       next:
-        name: "&f&l Halaman Selanjutnya"
-        description: "&7 Beralih ke halaman [number]"
+        name: <white><bold>Halaman Selanjutnya</bold></white>
+        description: <gray>Beralih ke halaman [number]</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l Warp Acak"
-        description: "&7 Hmm, di mana aku akan muncul?"
+        name: <white><bold>Warp Acak</bold></white>
+        description: <gray>Hmm, di mana aku akan muncul?</gray>
     tips:
-      click-to-previous: "&e Klik &7 untuk melihat halaman sebelumnya."
-      click-to-next: "&e Klik &7 untuk melihat halaman selanjutnya."
-      click-to-warp: "&e Klik &7 untuk warp."
+      click-to-previous: <yellow>Klik </yellow><gray>untuk melihat halaman sebelumnya.</gray>
+      click-to-next: <yellow>Klik </yellow><gray>untuk melihat halaman selanjutnya.</gray>
+      click-to-warp: <yellow>Klik </yellow><gray>untuk warp.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: alihkan tanda warp
-  enabled: "&a Warp kamu sekarang terlihat!"
-  disabled: "&c Warp kamu sekarang tersembunyi!"
+  enabled: <green>Warp kamu sekarang terlihat!</green>
+  disabled: <red>Warp kamu sekarang tersembunyi!</red>
   error:
-    no-permission: "&c Kamu tidak punya izin untuk melakukan itu!"
-    generic: "&c Terjadi kesalahan saat mengalihkan warp kamu."
-    no-warp: "&c Kamu tidak memiliki warp untuk dialihkan!"
+    no-permission: <red>Kamu tidak punya izin untuk melakukan itu!</red>
+    generic: <red>Terjadi kesalahan saat mengalihkan warp kamu.</red>
+    no-warp: <red>Kamu tidak memiliki warp untuk dialihkan!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -4,57 +4,55 @@ warp:
     description: teletrasporto al cartello Warp del giocatore
     parameters: "<nome giocatore>"
 warps:
-  deactivate: "&c Vecchio cartello Warp disattivato!"
+  deactivate: <red>Vecchio cartello Warp disattivato!</red>
   error:
-    does-not-exist: "&c Quel cartello Warp non esiste più!"
-    no-permission: "&c Non hai i permessi per farlo!"
-    no-remove: "&c Non puoi rimuovere quel cartello!"
-    no-warps-yet: "&c Non ci sono ancora Warp disponibili"
-    not-enough-level: "&c Il tuo livello dell'isola non è abbastanza alto!"
-    not-on-island: "&c Devi essere nella tua isola per farlo!"
-    not-safe: "&c Il Warp non è sicuro!"
-    your-level-is: "&c Il tuo livello dell'isola è solo di [level] e deve essere
-      maggiore di [required]. Esegui il comando del calcolo dei livelli per aggiornare
-      il livello."
-    not-correct-rank: "&c Non hai il rango corretto per impostare un Warp!"
+    does-not-exist: <red>Quel cartello Warp non esiste più!</red>
+    no-permission: <red>Non hai i permessi per farlo!</red>
+    no-remove: <red>Non puoi rimuovere quel cartello!</red>
+    no-warps-yet: <red>Non ci sono ancora Warp disponibili</red>
+    not-enough-level: <red>Il tuo livello dell'isola non è abbastanza alto!</red>
+    not-on-island: <red>Devi essere nella tua isola per farlo!</red>
+    not-safe: <red>Il Warp non è sicuro!</red>
+    your-level-is: <red>Il tuo livello dell'isola è solo di [level] e deve essere maggiore di [required]. Esegui il comando del calcolo dei livelli per aggiornare il livello.</red>
+    not-correct-rank: <red>Non hai il rango corretto per impostare un Warp!</red>
   help:
     description: apri il pannello dei Warp
-  player-warped: "&2 [name] teletrasportato al tuo cartello Warp [gamemode]!"
-  sign-removed: "&c Cartello Warp rimosso!"
-  success: "&a Successo!"
-  warpTip: "&6 Piazza un cartello Warp con [text] scritto nella prima riga"
-  warpToPlayersSign: "&6 Teletrasporto al cartello Warp di [player]"
+  player-warped: <dark_green>[name] teletrasportato al tuo cartello Warp [gamemode]!</dark_green>
+  sign-removed: <red>Cartello Warp rimosso!</red>
+  success: <green>Successo!</green>
+  warpTip: <gold>Piazza un cartello Warp con [text] scritto nella prima riga</gold>
+  warpToPlayersSign: <gold>Teletrasporto al cartello Warp di [player]</gold>
   gui:
     titles:
-      warp-title: "&0&l Cartelli Warp"
+      warp-title: <black><bold>Cartelli Warp</bold></black>
     buttons:
       previous:
-        name: "&f&l Pagina Precedente"
-        description: "&7 Passa alla pagina [number]"
+        name: <white><bold>Pagina Precedente</bold></white>
+        description: <gray>Passa alla pagina [number]</gray>
       next:
-        name: "&f&l Pagina Successiva"
-        description: "&7 Passa alla pagina [number]"
+        name: <white><bold>Pagina Successiva</bold></white>
+        description: <gray>Passa alla pagina [number]</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l Warp Casuale"
-        description: "&7 Hmm, dove apparirò?"
+        name: <white><bold>Warp Casuale</bold></white>
+        description: <gray>Hmm, dove apparirò?</gray>
     tips:
-      click-to-previous: "&e Clicca &7 per vedere la pagina precedente."
-      click-to-next: "&e Clicca &7 per vedere la pagina successiva."
-      click-to-warp: "&e Clicca &7 per teletrasportarti."
+      click-to-previous: <yellow>Clicca </yellow><gray>per vedere la pagina precedente.</gray>
+      click-to-next: <yellow>Clicca </yellow><gray>per vedere la pagina successiva.</gray>
+      click-to-warp: <yellow>Clicca </yellow><gray>per teletrasportarti.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: attiva/disattiva il cartello warp
-  enabled: "&a Il tuo Warp è ora visibile!"
-  disabled: "&c Il tuo Warp è ora nascosto!"
+  enabled: <green>Il tuo Warp è ora visibile!</green>
+  disabled: <red>Il tuo Warp è ora nascosto!</red>
   error:
-    no-permission: "&c Non hai i permessi per farlo!"
-    generic: "&c Si è verificato un errore durante la modifica del tuo Warp."
-    no-warp: "&c Non hai un Warp da attivare/disattivare!"
+    no-permission: <red>Non hai i permessi per farlo!</red>
+    generic: <red>Si è verificato un errore durante la modifica del tuo Warp.</red>
+    no-warp: <red>Non hai un Warp da attivare/disattivare!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -4,55 +4,55 @@ warp:
     description: プレイヤーのワープサインにワープする
     parameters: "<名>"
 warps:
-  deactivate: "&c 古いワープサインが無効になりました!"
+  deactivate: <red>古いワープサインが無効になりました!</red>
   error:
-    does-not-exist: "&c ああ、やられた！そのワープはもう存在しない！"
-    no-permission: "&c あなたにはそれを実行する権限がありません!"
-    no-remove: "&c その標識は削除できません!"
-    no-warps-yet: "&c ワープはまだ利用できません"
-    not-enough-level: "&c あなたの島のレベルは十分に高くありません!"
-    not-on-island: "&c それを実行するには、自分の島にいる必要があります。"
-    not-safe: "&c そのワープは安全ではありません!"
-    your-level-is: "&c あなたの島のレベルは [level] のみで、[required] より高くなければなりません。level コマンドを実行してください。"
-    not-correct-rank: "&c ワープを設定するための適切なランクがありません。"
+    does-not-exist: <red>ああ、やられた！そのワープはもう存在しない！</red>
+    no-permission: <red>あなたにはそれを実行する権限がありません!</red>
+    no-remove: <red>その標識は削除できません!</red>
+    no-warps-yet: <red>ワープはまだ利用できません</red>
+    not-enough-level: <red>あなたの島のレベルは十分に高くありません!</red>
+    not-on-island: <red>それを実行するには、自分の島にいる必要があります。</red>
+    not-safe: <red>そのワープは安全ではありません!</red>
+    your-level-is: <red>あなたの島のレベルは [level] のみで、[required] より高くなければなりません。level コマンドを実行してください。</red>
+    not-correct-rank: <red>ワープを設定するための適切なランクがありません。</red>
   help:
     description: ワープパネルを開く
-  player-warped: "&2 [name] があなたの [gamemode] ワープサインにワープしました!"
-  sign-removed: "&c ワープサインが削除されました!"
-  success: "&a 成功しました!"
-  warpTip: "&6 [text]を上部に記したワープサインを配置する"
-  warpToPlayersSign: "&6 [player]のサインにワープ"
+  player-warped: <dark_green>[name] があなたの [gamemode] ワープサインにワープしました!</dark_green>
+  sign-removed: <red>ワープサインが削除されました!</red>
+  success: <green>成功しました!</green>
+  warpTip: <gold>[text]を上部に記したワープサインを配置する</gold>
+  warpToPlayersSign: <gold>[player]のサインにワープ</gold>
   gui:
     titles:
-      warp-title: "&0&l ワープサイン"
+      warp-title: <black><bold>ワープサイン</bold></black>
     buttons:
       previous:
-        name: "&f&l 前のページ"
-        description: "&7 [number] ページに切り替える"
+        name: <white><bold>前のページ</bold></white>
+        description: <gray>[number] ページに切り替える</gray>
       next:
-        name: "&f&l 次のページ"
-        description: "&7 [number]ページに切り替える"
+        name: <white><bold>次のページ</bold></white>
+        description: <gray>[number]ページに切り替える</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l ランダムワープ"
-        description: "&7 うーん、どこに現れるんだろう？"
+        name: <white><bold>ランダムワープ</bold></white>
+        description: <gray>うーん、どこに現れるんだろう？</gray>
     tips:
-      click-to-previous: "&e 前のページを表示するには &7 をクリックします。"
-      click-to-next: "&e 次のページを表示するには &7 をクリックします。"
-      click-to-warp: "&e ワープするには &7 をクリックします。"
+      click-to-previous: <yellow>前のページを表示するには </yellow><gray>をクリックします。</gray>
+      click-to-next: <yellow>次のページを表示するには </yellow><gray>をクリックします。</gray>
+      click-to-warp: <yellow>ワープするには </yellow><gray>をクリックします。</gray>
   conversations:
-    prefix: "&l&6 [弁当箱]: &r"
+    prefix: '<gold><bold>[弁当箱]: </bold></gold><reset>'
 togglewarp:
   help:
     description: ワープサインを切り替える
-  enabled: "&a ワープが見えるようになりました!"
-  disabled: "&c ワープが非表示になりました!"
+  enabled: <green>ワープが見えるようになりました!</green>
+  disabled: <red>ワープが非表示になりました!</red>
   error:
-    no-permission: "&c あなたにはそれを実行する権限がありません!"
-    generic: "&c ワープの切り替え中にエラーが発生しました。"
-    no-warp: "&c 切り替えるワープがありません!"
+    no-permission: <red>あなたにはそれを実行する権限がありません!</red>
+    generic: <red>ワープの切り替え中にエラーが発生しました。</red>
+    no-warp: <red>切り替えるワープがありません!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -4,55 +4,55 @@ warp:
     description: 플레이어의 워프 표지판으로 이동
     parameters: "<플레이어 이름>"
 warps:
-  deactivate: "&c 오래된 워프 표지판이 비활성화되었습니다!"
+  deactivate: <red>오래된 워프 표지판이 비활성화되었습니다!</red>
   error:
-    does-not-exist: "&c 이런! 그 워프는 더 이상 존재하지 않습니다!"
-    no-permission: "&c 그 작업을 수행할 권한이 없습니다!"
-    no-remove: "&c 그 표지판을 제거할 수 없습니다!"
-    no-warps-yet: "&c 아직 사용 가능한 워프가 없습니다"
-    not-enough-level: "&c 섬 레벨이 충분히 높지 않습니다!"
-    not-on-island: "&c 자신의 섬에 있어야 합니다!"
-    not-safe: "&c 그 워프는 안전하지 않습니다!"
-    your-level-is: "&c 섬 레벨이 [level]뿐이며 [required]보다 높아야 합니다. 레벨 명령어를 실행하세요."
-    not-correct-rank: "&c 워프를 설정할 올바른 등급이 없습니다!"
+    does-not-exist: <red>이런! 그 워프는 더 이상 존재하지 않습니다!</red>
+    no-permission: <red>그 작업을 수행할 권한이 없습니다!</red>
+    no-remove: <red>그 표지판을 제거할 수 없습니다!</red>
+    no-warps-yet: <red>아직 사용 가능한 워프가 없습니다</red>
+    not-enough-level: <red>섬 레벨이 충분히 높지 않습니다!</red>
+    not-on-island: <red>자신의 섬에 있어야 합니다!</red>
+    not-safe: <red>그 워프는 안전하지 않습니다!</red>
+    your-level-is: <red>섬 레벨이 [level]뿐이며 [required]보다 높아야 합니다. 레벨 명령어를 실행하세요.</red>
+    not-correct-rank: <red>워프를 설정할 올바른 등급이 없습니다!</red>
   help:
     description: 워프 패널 열기
-  player-warped: "&2 [name]이(가) 당신의 [gamemode] 워프 표지판으로 이동했습니다!"
-  sign-removed: "&c 워프 표지판이 제거되었습니다!"
-  success: "&a 성공!"
-  warpTip: "&6 상단에 [text]가 적힌 워프 표지판을 배치하세요"
-  warpToPlayersSign: "&6 [player]의 표지판으로 이동 중"
+  player-warped: <dark_green>[name]이(가) 당신의 [gamemode] 워프 표지판으로 이동했습니다!</dark_green>
+  sign-removed: <red>워프 표지판이 제거되었습니다!</red>
+  success: <green>성공!</green>
+  warpTip: <gold>상단에 [text]가 적힌 워프 표지판을 배치하세요</gold>
+  warpToPlayersSign: <gold>[player]의 표지판으로 이동 중</gold>
   gui:
     titles:
-      warp-title: "&0&l 워프 표지판"
+      warp-title: <black><bold>워프 표지판</bold></black>
     buttons:
       previous:
-        name: "&f&l 이전 페이지"
-        description: "&7 [number] 페이지로 이동"
+        name: <white><bold>이전 페이지</bold></white>
+        description: <gray>[number] 페이지로 이동</gray>
       next:
-        name: "&f&l 다음 페이지"
-        description: "&7 [number] 페이지로 이동"
+        name: <white><bold>다음 페이지</bold></white>
+        description: <gray>[number] 페이지로 이동</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l 랜덤 워프"
-        description: "&7 음, 어디에 나타날까요?"
+        name: <white><bold>랜덤 워프</bold></white>
+        description: <gray>음, 어디에 나타날까요?</gray>
     tips:
-      click-to-previous: "&e 클릭 &7 이전 페이지 보기."
-      click-to-next: "&e 클릭 &7 다음 페이지 보기."
-      click-to-warp: "&e 클릭 &7 워프하기."
+      click-to-previous: <yellow>클릭 </yellow><gray>이전 페이지 보기.</gray>
+      click-to-next: <yellow>클릭 </yellow><gray>다음 페이지 보기.</gray>
+      click-to-warp: <yellow>클릭 </yellow><gray>워프하기.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: 워프 표지판 전환
-  enabled: "&a 워프가 이제 표시됩니다!"
-  disabled: "&c 워프가 이제 숨겨졌습니다!"
+  enabled: <green>워프가 이제 표시됩니다!</green>
+  disabled: <red>워프가 이제 숨겨졌습니다!</red>
   error:
-    no-permission: "&c 그 작업을 수행할 권한이 없습니다!"
-    generic: "&c 워프를 전환하는 중 오류가 발생했습니다."
-    no-warp: "&c 전환할 워프가 없습니다!"
+    no-permission: <red>그 작업을 수행할 권한이 없습니다!</red>
+    generic: <red>워프를 전환하는 중 오류가 발생했습니다.</red>
+    no-warp: <red>전환할 워프가 없습니다!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -4,56 +4,55 @@ warp:
     description: pārvietoties pie spēlētāja uzaicinājuma zīmes
     parameters: "<spēlētāja vārds>"
 warps:
-  deactivate: "&c Iepriekšēja uzaicinājuma zīme deaktivizēta!"
+  deactivate: <red>Iepriekšēja uzaicinājuma zīme deaktivizēta!</red>
   error:
-    does-not-exist: "&c Oh! Šī uzaicinājuma zīme vairs neeksistē!"
-    no-permission: "&c Tev nav atļaujas veikt šo darbību!"
-    no-remove: "&c Tu nevari noņemt šo zīmi!"
-    no-warps-yet: "&c Diemžēl neviens uzaicinājums nav pieejams."
-    not-enough-level: "&c Tavs salas līmenis nav pietiekošs."
-    not-on-island: "&c Tev ir jābūt uz savas salas, lai veiktu šo darbību!"
-    not-safe: "&c Šis uzaicinājums nav drošs!"
-    your-level-is: "&c Tavas salas līmenis ir [level], bet ir nepieciešams vismaz
-      [required]. Mēģini pārrēķināt salas līmeni."
-    not-correct-rank: "&c Jums nav atbilstošā ranga, lai iestatītu portālu!"
+    does-not-exist: <red>Oh! Šī uzaicinājuma zīme vairs neeksistē!</red>
+    no-permission: <red>Tev nav atļaujas veikt šo darbību!</red>
+    no-remove: <red>Tu nevari noņemt šo zīmi!</red>
+    no-warps-yet: <red>Diemžēl neviens uzaicinājums nav pieejams.</red>
+    not-enough-level: <red>Tavs salas līmenis nav pietiekošs.</red>
+    not-on-island: <red>Tev ir jābūt uz savas salas, lai veiktu šo darbību!</red>
+    not-safe: <red>Šis uzaicinājums nav drošs!</red>
+    your-level-is: <red>Tavas salas līmenis ir [level], bet ir nepieciešams vismaz [required]. Mēģini pārrēķināt salas līmeni.</red>
+    not-correct-rank: <red>Jums nav atbilstošā ranga, lai iestatītu portālu!</red>
   help:
     description: atver uzaicinājumu zīmju sarakstu
-  player-warped: "&2 [name] ieradās pie jūsu [gamemode] uzaicinājuma zīmes!"
-  sign-removed: "&c Uzaicinājuma zīme noņemta!"
-  success: "&a Izdevās!"
-  warpTip: "&6 Izveido zīmi ar [text] pirmajā rindā"
-  warpToPlayersSign: "&6 Pārvietojas uz [player] uzaicinājuma zīmi."
+  player-warped: <dark_green>[name] ieradās pie jūsu [gamemode] uzaicinājuma zīmes!</dark_green>
+  sign-removed: <red>Uzaicinājuma zīme noņemta!</red>
+  success: <green>Izdevās!</green>
+  warpTip: <gold>Izveido zīmi ar [text] pirmajā rindā</gold>
+  warpToPlayersSign: <gold>Pārvietojas uz [player] uzaicinājuma zīmi.</gold>
   gui:
     titles:
-      warp-title: "&0&l Uzaicinājuma Zīmes"
+      warp-title: <black><bold>Uzaicinājuma Zīmes</bold></black>
     buttons:
       previous:
-        name: "&f&l Iepriekšējā lapa"
-        description: "&7 Pārslēgt uz lapu [number]"
+        name: <white><bold>Iepriekšējā lapa</bold></white>
+        description: <gray>Pārslēgt uz lapu [number]</gray>
       next:
-        name: "&f&l Nākamā lapa"
-        description: "&7 Pārslēgt uz lapu [number]"
+        name: <white><bold>Nākamā lapa</bold></white>
+        description: <gray>Pārslēgt uz lapu [number]</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l Nejaušs uzaicinājums"
-        description: "&7 Hmm, kur es parādīšos?"
+        name: <white><bold>Nejaušs uzaicinājums</bold></white>
+        description: <gray>Hmm, kur es parādīšos?</gray>
     tips:
-      click-to-previous: "&e Klikšķiniet &7, lai skatītu iepriekšējo lapu."
-      click-to-next: "&e Klikšķiniet &7, lai skatītu nākamo lapu."
-      click-to-warp: "&e Klikšķiniet &7, lai pārvietotos."
+      click-to-previous: <yellow>Klikšķiniet </yellow><gray>, lai skatītu iepriekšējo lapu.</gray>
+      click-to-next: <yellow>Klikšķiniet </yellow><gray>, lai skatītu nākamo lapu.</gray>
+      click-to-warp: <yellow>Klikšķiniet </yellow><gray>, lai pārvietotos.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: pārslēgt uzaicinājuma zīmi
-  enabled: "&a Jūsu portāls tagad ir redzams!"
-  disabled: "&c Jūsu portāls tagad ir paslēpts!"
+  enabled: <green>Jūsu portāls tagad ir redzams!</green>
+  disabled: <red>Jūsu portāls tagad ir paslēpts!</red>
   error:
-    no-permission: "&c Jums nav atļaujas veikt šo darbību!"
-    generic: "&c Kļūda pārslēdzot portālu."
-    no-warp: "&c Jums nav portāla, ko pārslēgt!"
+    no-permission: <red>Jums nav atļaujas veikt šo darbību!</red>
+    generic: <red>Kļūda pārslēdzot portālu.</red>
+    no-warp: <red>Jums nav portāla, ko pārslēgt!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -4,56 +4,55 @@ warp:
     description: teleporteer naar een speler zijn warp bord
     parameters: "<speler>"
 warps:
-  deactivate: "&c Oude warp bord is gedeactiveerd!"
+  deactivate: <red>Oude warp bord is gedeactiveerd!</red>
   error:
-    does-not-exist: "&c Oh nee! Deze warp bestaat niet meer!"
-    no-permission: "&c Je hebt geen permissies om dit te doen!"
-    no-remove: "&c Je kan dit bord niet weghalen!"
-    no-warps-yet: "&c Er bestaan nog geen warps op dit moment"
-    not-enough-level: "&c Je eiland level is nog niet hoog genoeg!"
-    not-on-island: "&c Je moet een eiland hebben om dit te doen!"
-    not-safe: "&c Deze warp is niet veilig!"
-    your-level-is: "&c Je eiland level is [level], maar het moet op zijn minst [required]
-      zijn. Gebruik het level commando."
-    not-correct-rank: "&c Je hebt niet de correcte rank om een warp te maken!"
+    does-not-exist: <red>Oh nee! Deze warp bestaat niet meer!</red>
+    no-permission: <red>Je hebt geen permissies om dit te doen!</red>
+    no-remove: <red>Je kan dit bord niet weghalen!</red>
+    no-warps-yet: <red>Er bestaan nog geen warps op dit moment</red>
+    not-enough-level: <red>Je eiland level is nog niet hoog genoeg!</red>
+    not-on-island: <red>Je moet een eiland hebben om dit te doen!</red>
+    not-safe: <red>Deze warp is niet veilig!</red>
+    your-level-is: <red>Je eiland level is [level], maar het moet op zijn minst [required] zijn. Gebruik het level commando.</red>
+    not-correct-rank: <red>Je hebt niet de correcte rank om een warp te maken!</red>
   help:
     description: open het warp paneel
-  player-warped: "&2 [name] teleporteerde naar jou [gamemode] warp!"
-  sign-removed: "&c Warp bord verwijderd!"
-  success: "&a Geslaagd!"
-  warpTip: "&6 Plaats een warp bord met [text] op de eerste regel"
-  warpToPlayersSign: "&6 Teleporteren naar [player]'s warp"
+  player-warped: <dark_green>[name] teleporteerde naar jou [gamemode] warp!</dark_green>
+  sign-removed: <red>Warp bord verwijderd!</red>
+  success: <green>Geslaagd!</green>
+  warpTip: <gold>Plaats een warp bord met [text] op de eerste regel</gold>
+  warpToPlayersSign: <gold>Teleporteren naar [player]'s warp</gold>
   gui:
     titles:
-      warp-title: "&0&l Warp Borden"
+      warp-title: <black><bold>Warp Borden</bold></black>
     buttons:
       previous:
-        name: "&f&l Vorige pagina"
-        description: "&7 Ga naar pagina [number]"
+        name: <white><bold>Vorige pagina</bold></white>
+        description: <gray>Ga naar pagina [number]</gray>
       next:
-        name: "&f&l Volgende pagina"
-        description: "&7 Ga naar pagina [number]"
+        name: <white><bold>Volgende pagina</bold></white>
+        description: <gray>Ga naar pagina [number]</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l Willekeurige Warp"
-        description: "&7 Hmm, waar ga ik heen?"
+        name: <white><bold>Willekeurige Warp</bold></white>
+        description: <gray>Hmm, waar ga ik heen?</gray>
     tips:
-      click-to-previous: "&e Klik &7 om naar de vorige pagina te gaan."
-      click-to-next: "&e Klik &7 om naar de volgende pagina te gaan."
-      click-to-warp: "&e Klik &7 om te teleporteren."
+      click-to-previous: <yellow>Klik </yellow><gray>om naar de vorige pagina te gaan.</gray>
+      click-to-next: <yellow>Klik </yellow><gray>om naar de volgende pagina te gaan.</gray>
+      click-to-warp: <yellow>Klik </yellow><gray>om te teleporteren.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: schakel het warpbord
-  enabled: "&a Je warp is nu zichtbaar!"
-  disabled: "&c Je warp is nu verborgen!"
+  enabled: <green>Je warp is nu zichtbaar!</green>
+  disabled: <red>Je warp is nu verborgen!</red>
   error:
-    no-permission: "&c Je hebt geen permissies om dit te doen!"
-    generic: "&c Er is een fout opgetreden bij het omschakelen van je warp."
-    no-warp: "&c Je hebt geen warp om te schakelen!"
+    no-permission: <red>Je hebt geen permissies om dit te doen!</red>
+    generic: <red>Er is een fout opgetreden bij het omschakelen van je warp.</red>
+    no-warp: <red>Je hebt geen warp om te schakelen!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -4,56 +4,55 @@ warp:
     description: teleportuje cię do tabliczki innego gracza
     parameters: "<gracz>"
 warps:
-  deactivate: "&c Stary teleport został zdezaktywowany!"
+  deactivate: <red>Stary teleport został zdezaktywowany!</red>
   error:
-    does-not-exist: "&c Ten teleport nie istnieje."
-    no-permission: "&c Brak uprawnień!"
-    no-remove: "&c Nie możesz usunąć tej tabliczki!"
-    no-warps-yet: "&c Nie ma jeszcze stworzonych teleportów."
-    not-enough-level: "&c Twój poziom wyspy nie jest wystarczająco wysoki!"
-    not-on-island: "&c Musisz być na wyspie, by to zrobić."
-    not-safe: "&c Ten teleport nie jest bezpieczny!"
-    your-level-is: "&c Twój poziom wyspy to [level], a musi wynosić co najmniej [required].
-      Użyj komendy /is level."
-    not-correct-rank: "&c Nie masz odpowiedniej rangi, aby ustawić warp!"
+    does-not-exist: <red>Ten teleport nie istnieje.</red>
+    no-permission: <red>Brak uprawnień!</red>
+    no-remove: <red>Nie możesz usunąć tej tabliczki!</red>
+    no-warps-yet: <red>Nie ma jeszcze stworzonych teleportów.</red>
+    not-enough-level: <red>Twój poziom wyspy nie jest wystarczająco wysoki!</red>
+    not-on-island: <red>Musisz być na wyspie, by to zrobić.</red>
+    not-safe: <red>Ten teleport nie jest bezpieczny!</red>
+    your-level-is: <red>Twój poziom wyspy to [level], a musi wynosić co najmniej [required]. Użyj komendy /is level.</red>
+    not-correct-rank: <red>Nie masz odpowiedniej rangi, aby ustawić warp!</red>
   help:
     description: otwiera panel warpów
-  player-warped: "&2 [name] teleportował się do twojej tabliczki!"
-  sign-removed: "&c Usunięto tabliczkę!"
-  success: "&a Sukces!"
-  warpTip: "&6 Postaw tabliczkę z napisem [text]"
-  warpToPlayersSign: "&6 Teleportowanie do tabliczki gracza [player]"
+  player-warped: <dark_green>[name] teleportował się do twojej tabliczki!</dark_green>
+  sign-removed: <red>Usunięto tabliczkę!</red>
+  success: <green>Sukces!</green>
+  warpTip: <gold>Postaw tabliczkę z napisem [text]</gold>
+  warpToPlayersSign: <gold>Teleportowanie do tabliczki gracza [player]</gold>
   gui:
     titles:
-      warp-title: "&0&l Lista dostępnych wysp"
+      warp-title: <black><bold>Lista dostępnych wysp</bold></black>
     buttons:
       previous:
-        name: "&f&l Poprzednia strona"
-        description: "&7 Przełącz na stronę [number]"
+        name: <white><bold>Poprzednia strona</bold></white>
+        description: <gray>Przełącz na stronę [number]</gray>
       next:
-        name: "&f&l następna strona"
-        description: "&7 Przełącz na stronę [number]"
+        name: <white><bold>następna strona</bold></white>
+        description: <gray>Przełącz na stronę [number]</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l Losowa wyspa"
-        description: "&7 Hmm, gdzie się pojawię?"
+        name: <white><bold>Losowa wyspa</bold></white>
+        description: <gray>Hmm, gdzie się pojawię?</gray>
     tips:
-      click-to-previous: "&e Kliknij &7, aby wyświetlić poprzednią stronę."
-      click-to-next: "&e Kliknij &7, aby wyświetlić następną stronę."
-      click-to-warp: "&e Kliknij &7, aby przenieść."
+      click-to-previous: <yellow>Kliknij </yellow><gray>, aby wyświetlić poprzednią stronę.</gray>
+      click-to-next: <yellow>Kliknij </yellow><gray>, aby wyświetlić następną stronę.</gray>
+      click-to-warp: <yellow>Kliknij </yellow><gray>, aby przenieść.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: przełącz tabliczkę warp
-  enabled: "&a Twój warp jest teraz widoczny!"
-  disabled: "&c Twój warp jest teraz ukryty!"
+  enabled: <green>Twój warp jest teraz widoczny!</green>
+  disabled: <red>Twój warp jest teraz ukryty!</red>
   error:
-    no-permission: "&c Brak uprawnień!"
-    generic: "&c Wystąpił błąd podczas przełączania twojego warpu."
-    no-warp: "&c Nie masz warpu do przełączenia!"
+    no-permission: <red>Brak uprawnień!</red>
+    generic: <red>Wystąpił błąd podczas przełączania twojego warpu.</red>
+    no-warp: <red>Nie masz warpu do przełączenia!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/pt-BR.yml
+++ b/src/main/resources/locales/pt-BR.yml
@@ -4,56 +4,55 @@ warp:
     description: teletransportar para o sinal de warp do jogador
     parameters: "<nome do jogador>"
 warps:
-  deactivate: "&c Sinal de warp antigo desativado!"
+  deactivate: <red>Sinal de warp antigo desativado!</red>
   error:
-    does-not-exist: "&c Eita! Esse warp não existe mais!"
-    no-permission: "&c Você não tem permissão para fazer isso!"
-    no-remove: "&c Você não pode remover esse sinal!"
-    no-warps-yet: "&c Não há warps disponíveis ainda"
-    not-enough-level: "&c O nível da sua ilha não é alto o suficiente!"
-    not-on-island: "&c Você precisa estar na sua ilha para fazer isso!"
-    not-safe: "&c Esse warp não é seguro!"
-    your-level-is: "&c O nível da sua ilha é apenas [level] e deve ser maior que [required].
-      Execute o comando de nível."
-    not-correct-rank: "&c Você não tem o cargo correto para definir um warp!"
+    does-not-exist: <red>Eita! Esse warp não existe mais!</red>
+    no-permission: <red>Você não tem permissão para fazer isso!</red>
+    no-remove: <red>Você não pode remover esse sinal!</red>
+    no-warps-yet: <red>Não há warps disponíveis ainda</red>
+    not-enough-level: <red>O nível da sua ilha não é alto o suficiente!</red>
+    not-on-island: <red>Você precisa estar na sua ilha para fazer isso!</red>
+    not-safe: <red>Esse warp não é seguro!</red>
+    your-level-is: <red>O nível da sua ilha é apenas [level] e deve ser maior que [required]. Execute o comando de nível.</red>
+    not-correct-rank: <red>Você não tem o cargo correto para definir um warp!</red>
   help:
     description: abrir o painel de warps
-  player-warped: "&2 [name] teletransportou para o seu sinal de warp [gamemode]!"
-  sign-removed: "&c Sinal de warp removido!"
-  success: "&a Sucesso!"
-  warpTip: "&6 Coloque um sinal de warp com [text] no topo"
-  warpToPlayersSign: "&6 Teletransportando para o sinal de [player]"
+  player-warped: <dark_green>[name] teletransportou para o seu sinal de warp [gamemode]!</dark_green>
+  sign-removed: <red>Sinal de warp removido!</red>
+  success: <green>Sucesso!</green>
+  warpTip: <gold>Coloque um sinal de warp com [text] no topo</gold>
+  warpToPlayersSign: <gold>Teletransportando para o sinal de [player]</gold>
   gui:
     titles:
-      warp-title: "&0&l Sinais de Warp"
+      warp-title: <black><bold>Sinais de Warp</bold></black>
     buttons:
       previous:
-        name: "&f&l Página Anterior"
-        description: "&7 Mudar para a página [number]"
+        name: <white><bold>Página Anterior</bold></white>
+        description: <gray>Mudar para a página [number]</gray>
       next:
-        name: "&f&l Próxima Página"
-        description: "&7 Mudar para a página [number]"
+        name: <white><bold>Próxima Página</bold></white>
+        description: <gray>Mudar para a página [number]</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l Warp Aleatório"
-        description: "&7 Hmm, onde vou aparecer?"
+        name: <white><bold>Warp Aleatório</bold></white>
+        description: <gray>Hmm, onde vou aparecer?</gray>
     tips:
-      click-to-previous: "&e Clique &7 para ver a página anterior."
-      click-to-next: "&e Clique &7 para ver a próxima página."
-      click-to-warp: "&e Clique &7 para teletransportar."
+      click-to-previous: <yellow>Clique </yellow><gray>para ver a página anterior.</gray>
+      click-to-next: <yellow>Clique </yellow><gray>para ver a próxima página.</gray>
+      click-to-warp: <yellow>Clique </yellow><gray>para teletransportar.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: alternar o sinal de warp
-  enabled: "&a Seu warp agora está visível!"
-  disabled: "&c Seu warp agora está oculto!"
+  enabled: <green>Seu warp agora está visível!</green>
+  disabled: <red>Seu warp agora está oculto!</red>
   error:
-    no-permission: "&c Você não tem permissão para fazer isso!"
-    generic: "&c Ocorreu um erro ao alternar seu warp."
-    no-warp: "&c Você não tem um warp para alternar!"
+    no-permission: <red>Você não tem permissão para fazer isso!</red>
+    generic: <red>Ocorreu um erro ao alternar seu warp.</red>
+    no-warp: <red>Você não tem um warp para alternar!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -4,56 +4,55 @@ warp:
     description: teletransportar para o sinal de warp do jogador
     parameters: "<nome do jogador>"
 warps:
-  deactivate: "&c Sinal de warp antigo desativado!"
+  deactivate: <red>Sinal de warp antigo desativado!</red>
   error:
-    does-not-exist: "&c Esse warp já não existe!"
-    no-permission: "&c Não tens permissão para fazer isso!"
-    no-remove: "&c Não podes remover esse sinal!"
-    no-warps-yet: "&c Ainda não há warps disponíveis"
-    not-enough-level: "&c O nível da tua ilha não é suficientemente alto!"
-    not-on-island: "&c Tens de estar na tua ilha para fazer isso!"
-    not-safe: "&c Esse warp não é seguro!"
-    your-level-is: "&c O nível da tua ilha é apenas [level] e deve ser superior a [required].
-      Executa o comando de nível."
-    not-correct-rank: "&c Não tens o cargo correto para definir um warp!"
+    does-not-exist: <red>Esse warp já não existe!</red>
+    no-permission: <red>Não tens permissão para fazer isso!</red>
+    no-remove: <red>Não podes remover esse sinal!</red>
+    no-warps-yet: <red>Ainda não há warps disponíveis</red>
+    not-enough-level: <red>O nível da tua ilha não é suficientemente alto!</red>
+    not-on-island: <red>Tens de estar na tua ilha para fazer isso!</red>
+    not-safe: <red>Esse warp não é seguro!</red>
+    your-level-is: <red>O nível da tua ilha é apenas [level] e deve ser superior a [required]. Executa o comando de nível.</red>
+    not-correct-rank: <red>Não tens o cargo correto para definir um warp!</red>
   help:
     description: abrir o painel de warps
-  player-warped: "&2 [name] teletransportou para o teu sinal de warp [gamemode]!"
-  sign-removed: "&c Sinal de warp removido!"
-  success: "&a Sucesso!"
-  warpTip: "&6 Coloca um sinal de warp com [text] no topo"
-  warpToPlayersSign: "&6 A teletransportar para o sinal de [player]"
+  player-warped: <dark_green>[name] teletransportou para o teu sinal de warp [gamemode]!</dark_green>
+  sign-removed: <red>Sinal de warp removido!</red>
+  success: <green>Sucesso!</green>
+  warpTip: <gold>Coloca um sinal de warp com [text] no topo</gold>
+  warpToPlayersSign: <gold>A teletransportar para o sinal de [player]</gold>
   gui:
     titles:
-      warp-title: "&0&l Sinais de Warp"
+      warp-title: <black><bold>Sinais de Warp</bold></black>
     buttons:
       previous:
-        name: "&f&l Página Anterior"
-        description: "&7 Mudar para a página [number]"
+        name: <white><bold>Página Anterior</bold></white>
+        description: <gray>Mudar para a página [number]</gray>
       next:
-        name: "&f&l Próxima Página"
-        description: "&7 Mudar para a página [number]"
+        name: <white><bold>Próxima Página</bold></white>
+        description: <gray>Mudar para a página [number]</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l Warp Aleatório"
-        description: "&7 Hmm, onde vou aparecer?"
+        name: <white><bold>Warp Aleatório</bold></white>
+        description: <gray>Hmm, onde vou aparecer?</gray>
     tips:
-      click-to-previous: "&e Clica &7 para ver a página anterior."
-      click-to-next: "&e Clica &7 para ver a próxima página."
-      click-to-warp: "&e Clica &7 para teletransportar."
+      click-to-previous: <yellow>Clica </yellow><gray>para ver a página anterior.</gray>
+      click-to-next: <yellow>Clica </yellow><gray>para ver a próxima página.</gray>
+      click-to-warp: <yellow>Clica </yellow><gray>para teletransportar.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: alternar o sinal de warp
-  enabled: "&a O teu warp está agora visível!"
-  disabled: "&c O teu warp está agora oculto!"
+  enabled: <green>O teu warp está agora visível!</green>
+  disabled: <red>O teu warp está agora oculto!</red>
   error:
-    no-permission: "&c Não tens permissão para fazer isso!"
-    generic: "&c Ocorreu um erro ao alternar o teu warp."
-    no-warp: "&c Não tens um warp para alternar!"
+    no-permission: <red>Não tens permissão para fazer isso!</red>
+    generic: <red>Ocorreu um erro ao alternar o teu warp.</red>
+    no-warp: <red>Não tens um warp para alternar!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -4,56 +4,55 @@ warp:
     description: teleportare la semnul de warp al jucătorului
     parameters: "<numele jucătorului>"
 warps:
-  deactivate: "&c Semnul de warp vechi a fost dezactivat!"
+  deactivate: <red>Semnul de warp vechi a fost dezactivat!</red>
   error:
-    does-not-exist: "&c Acel warp nu mai există!"
-    no-permission: "&c Nu ai permisiunea să faci asta!"
-    no-remove: "&c Nu poți elimina acel semn!"
-    no-warps-yet: "&c Nu există warps disponibile încă"
-    not-enough-level: "&c Nivelul insulei tale nu este suficient de ridicat!"
-    not-on-island: "&c Trebuie să fii pe insula ta pentru a face asta!"
-    not-safe: "&c Acel warp nu este sigur!"
-    your-level-is: "&c Nivelul insulei tale este doar [level] și trebuie să fie mai mare
-      decât [required]. Rulează comanda de nivel."
-    not-correct-rank: "&c Nu ai rangul corect pentru a seta un warp!"
+    does-not-exist: <red>Acel warp nu mai există!</red>
+    no-permission: <red>Nu ai permisiunea să faci asta!</red>
+    no-remove: <red>Nu poți elimina acel semn!</red>
+    no-warps-yet: <red>Nu există warps disponibile încă</red>
+    not-enough-level: <red>Nivelul insulei tale nu este suficient de ridicat!</red>
+    not-on-island: <red>Trebuie să fii pe insula ta pentru a face asta!</red>
+    not-safe: <red>Acel warp nu este sigur!</red>
+    your-level-is: <red>Nivelul insulei tale este doar [level] și trebuie să fie mai mare decât [required]. Rulează comanda de nivel.</red>
+    not-correct-rank: <red>Nu ai rangul corect pentru a seta un warp!</red>
   help:
     description: deschide panoul de warps
-  player-warped: "&2 [name] s-a teleportat la semnul tău de warp [gamemode]!"
-  sign-removed: "&c Semnul de warp a fost eliminat!"
-  success: "&a Succes!"
-  warpTip: "&6 Plasează un semn de warp cu [text] în partea de sus"
-  warpToPlayersSign: "&6 Teleportare la semnul lui [player]"
+  player-warped: <dark_green>[name] s-a teleportat la semnul tău de warp [gamemode]!</dark_green>
+  sign-removed: <red>Semnul de warp a fost eliminat!</red>
+  success: <green>Succes!</green>
+  warpTip: <gold>Plasează un semn de warp cu [text] în partea de sus</gold>
+  warpToPlayersSign: <gold>Teleportare la semnul lui [player]</gold>
   gui:
     titles:
-      warp-title: "&0&l Semne Warp"
+      warp-title: <black><bold>Semne Warp</bold></black>
     buttons:
       previous:
-        name: "&f&l Pagina Anterioară"
-        description: "&7 Treci la pagina [number]"
+        name: <white><bold>Pagina Anterioară</bold></white>
+        description: <gray>Treci la pagina [number]</gray>
       next:
-        name: "&f&l Pagina Următoare"
-        description: "&7 Treci la pagina [number]"
+        name: <white><bold>Pagina Următoare</bold></white>
+        description: <gray>Treci la pagina [number]</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l Warp Aleatoriu"
-        description: "&7 Hmm, unde voi apărea?"
+        name: <white><bold>Warp Aleatoriu</bold></white>
+        description: <gray>Hmm, unde voi apărea?</gray>
     tips:
-      click-to-previous: "&e Apasă &7 pentru a vedea pagina anterioară."
-      click-to-next: "&e Apasă &7 pentru a vedea pagina următoare."
-      click-to-warp: "&e Apasă &7 pentru teleportare."
+      click-to-previous: <yellow>Apasă </yellow><gray>pentru a vedea pagina anterioară.</gray>
+      click-to-next: <yellow>Apasă </yellow><gray>pentru a vedea pagina următoare.</gray>
+      click-to-warp: <yellow>Apasă </yellow><gray>pentru teleportare.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: comută semnul de warp
-  enabled: "&a Warp-ul tău este acum vizibil!"
-  disabled: "&c Warp-ul tău este acum ascuns!"
+  enabled: <green>Warp-ul tău este acum vizibil!</green>
+  disabled: <red>Warp-ul tău este acum ascuns!</red>
   error:
-    no-permission: "&c Nu ai permisiunea să faci asta!"
-    generic: "&c A apărut o eroare la comutarea warp-ului tău."
-    no-warp: "&c Nu ai un warp de comutat!"
+    no-permission: <red>Nu ai permisiunea să faci asta!</red>
+    generic: <red>A apărut o eroare la comutarea warp-ului tău.</red>
+    no-warp: <red>Nu ai un warp de comutat!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -71,4 +71,4 @@ protection:
   flags:
     PLACE_WARP:
       name: Размещение варпа
-      description: Предотвращает размещение варпа
+      description: Разрешает размещение варпа

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -1,65 +1,78 @@
-###########################################################################################
-# Это YML файл. Будьте осторожны при редактировании. Проверяйте свои правки              #
-# в YAML валидаторе, например, на http://yaml-online-parser.appspot.com                  #
-###########################################################################################
+# ######################################################################################## #
+# Это YML файл. Будьте осторожны при редактировании. Проверяйте свои правки                #
+# в YAML валидаторе, например, на http://yaml-online-parser.appspot.com                    #
+# ######################################################################################## #
 
 warp:
   help:
-    description: телепортироваться на знак варпа игрока
-    parameters: "<название>"
+    description: телепортироваться на варп игрока
+    parameters: <игрок>
 warps:
-  deactivate: "&c Старый знак телепортации деактивирован!"
+  deactivate: <red>Старый варп деактивирован!</red>
   error:
-    does-not-exist: "&c Этот знак телепорта больше не существует!"
-    no-permission: "&c У вас нет разрешения на это!"
-    no-remove: "&c Вы не можете удалить этот знак!"
-    no-warps-yet: "&c Телепортов пока нет"
-    not-enough-level: "&c Ваш уровень острова недостаточно высок!"
-    not-on-island: "&c Вы должны быть на вашем острове, чтобы сделать это!"
-    not-safe: "&c Место назначения не является безопасным!"
-    your-level-is: "&c Уровень вашего острова всего [level] и должен быть выше [required].
-      Запустите команду уровня."
-    not-correct-rank: "&c У вас нет необходимого ранга для установки варпа!"
+    does-not-exist: <red>Ой! Этот варп больше не существует!</red>
+    no-permission: <red>У вас нет разрешения на это!</red>
+    no-remove: <red>Вы не можете удалить этот варп!</red>
+    no-warps-yet: <red>В данный момент нет доступных варпов.</red>
+    not-enough-level: <red>Уровень вашего острова недостаточно высок!</red>
+    not-on-island: <red>Вы должны быть на своём острове, чтобы сделать это!</red>
+    not-safe: <red>Этот варп небезопасен!</red>
+    your-level-is: <red>Уровень вашего острова всего [level] и должен быть выше [required].</red>
+    not-correct-rank: <red>У вас недопустимый ранг, чтобы установить варп!</red>
   help:
     description: открыть панель варпов
-  player-warped: "&2 [name] телепортировался к вашему знаку варпа [gamemode]!"
-  sign-removed: "&c Знак варпа удалён!"
-  success: "&a Успех!"
-  warpTip: "&6 Поместите знак варпа с [text] в первой строке"
-  warpToPlayersSign: "&6 Телепортация к знаку [player]"
+  player-warped: <dark_green>[name] телепортировался на ваш варп [gamemode]!</dark_green>
+  sign-removed: <red>Варп удалён!</red>
+  success: <green>Успех!</green>
+  warpTip: <gold>Разместите варп с "[text]" вверху таблички.</gold>
+  warpToPlayersSign: <gold>Телепортация на варп игрока [player]</gold>
+  
   gui:
     titles:
-      warp-title: "&0&l Знаки телепортации"
+      # Название панели.
+      warp-title: <black><bold>Варпы игроков</bold></black>
     buttons:
+      # Кнопка возврата на предыдущую страницу.
       previous:
-        name: "&f&l Предыдущая страница"
-        description: "&7 Переключить на страницу [number]"
+        name: <white><bold>Предыдущая страница</bold></white>
+        description: <gray>Перейти на страницу [number]</gray>
+      # Кнопка перехода на следующую страницу.
       next:
-        name: "&f&l Следующая страница"
-        description: "&7 Переключить на страницу [number]"
+        name: <white><bold>Следующая страница</bold></white>
+        description: <gray>Перейти на страницу [number]</gray>
+      # Кнопка телепортации на варп игрока.
       warp:
-        name: "&f&l [name]"
-        description: "[sign_text]"
+        name: <white><bold>[name]</bold></white>
+        description: '[sign_text]'
+      # Кнопка случайной телепортации на варп игрока.
       random:
-        name: "&f&l Случайный варп"
-        description: "&7 Хм, где я появлюсь?"
+        name: <white><bold>Случайная телепортация</bold></white>
+        description: <gray>Хм, куда же я попаду?</gray>
     tips:
-      click-to-previous: "&e Нажмите &7 для перехода на предыдущую страницу."
-      click-to-next: "&e Нажмите &7 для перехода на следующую страницу."
-      click-to-warp: "&e Нажмите &7 для телепортации."
+      click-to-previous: <yellow>Нажмите</yellow><gray>, чтобы посмотреть предыдущую
+        страницу.</gray>
+      click-to-next: <yellow>Нажмите</yellow><gray>, чтобы посмотреть следующую страницу.</gray>
+      click-to-warp: <yellow>Нажмите</yellow><gray>, чтобы телепортироваться.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    # Префикс для сообщений от сервера.
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
+  next: '&6ледующая страница'
+  previous: '&6Предыдущая страница'
+  title: Телепорт Знаки
+  random: '&4Случайный телепорт'
+
 togglewarp:
   help:
-    description: переключить знак варпа
-  enabled: "&a Ваш варп теперь виден!"
-  disabled: "&c Ваш варп теперь скрыт!"
+    description: вкл/выкл варп
+  enabled: <green>Ваш варп теперь виден!</green>
+  disabled: <red>Ваш варп был скрыт!</red>
   error:
-    no-permission: "&c У вас нет разрешения на это!"
-    generic: "&c Произошла ошибка при переключении варпа."
-    no-warp: "&c У вас нет варпа для переключения!"
+    no-permission: <red>У вас нет разрешения на это!</red>
+    generic: <red>Произошла ошибка при переключении вашего варпа.</red>
+    no-warp: <red>У вас нет варпа для переключения!</red>
+
 protection:
   flags:
     PLACE_WARP:
-      name: Разместить варп
-      description: Разрешить размещение знака варпа
+      name: Размещение варпа
+      description: Предотвращает размещение варпа

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -56,10 +56,6 @@ warps:
   conversations:
     # Префикс для сообщений от сервера.
     prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
-  next: '&6ледующая страница'
-  previous: '&6Предыдущая страница'
-  title: Телепорт Знаки
-  random: '&4Случайный телепорт'
 
 togglewarp:
   help:

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -4,55 +4,55 @@ warp:
     description: Oyuncunun warp tabelasına ışınlan
     parameters: "<oyuncu adı>"
 warps:
-  deactivate: "&c Eski warp tabelası devre dışı bırakıldı!"
+  deactivate: <red>Eski warp tabelası devre dışı bırakıldı!</red>
   error:
-    does-not-exist: "&c Üzgünüm. Böyle bir warp artık yok!"
-    no-permission: "&4 Buna yetkin yok!"
-    no-remove: "&4 Bu tabelayı kaldıramazsın!"
-    no-warps-yet: "&4 Böyle bir warp henüz yok."
-    not-enough-level: "&4 Bunu koyman için daha fazla ada leveline ihtiyacın var."
-    not-on-island: "&4 Adanda değilsin."
-    not-safe: "&4 Ada warpi güvenli değil!"
-    your-level-is: "&9 Ada levelin &e[level] &9ve &e[required]&9'den fazla olması gerek!"
-    not-correct-rank: "&c Bir warp ayarlamak için doğru rütbeniz yok!"
+    does-not-exist: <red>Üzgünüm. Böyle bir warp artık yok!</red>
+    no-permission: <dark_red>Buna yetkin yok!</dark_red>
+    no-remove: <dark_red>Bu tabelayı kaldıramazsın!</dark_red>
+    no-warps-yet: <dark_red>Böyle bir warp henüz yok.</dark_red>
+    not-enough-level: <dark_red>Bunu koyman için daha fazla ada leveline ihtiyacın var.</dark_red>
+    not-on-island: <dark_red>Adanda değilsin.</dark_red>
+    not-safe: <dark_red>Ada warpi güvenli değil!</dark_red>
+    your-level-is: <blue>Ada levelin </blue><yellow>[level] </yellow><blue>ve </blue><yellow>[required]</yellow><blue>'den fazla olması gerek!</blue>
+    not-correct-rank: <red>Bir warp ayarlamak için doğru rütbeniz yok!</red>
   help:
     description: Warp panelini açar.
-  player-warped: "&d [name] &9 [gamemode] warp tabelana ışınlandı!"
-  sign-removed: "&4 Warp tabelası kaldırıldı!"
-  success: "&a Başarılı!"
-  warpTip: "&6 Warp açmak için tabelanın en üstüne &a[text] &9yaz!"
-  warpToPlayersSign: "&d [player] &9 warpına gidiliyor!"
+  player-warped: <light_purple>[name] </light_purple><blue>[gamemode] warp tabelana ışınlandı!</blue>
+  sign-removed: <dark_red>Warp tabelası kaldırıldı!</dark_red>
+  success: <green>Başarılı!</green>
+  warpTip: <gold>Warp açmak için tabelanın en üstüne </gold><green>[text] </green><blue>yaz!</blue>
+  warpToPlayersSign: <light_purple>[player] </light_purple><blue>warpına gidiliyor!</blue>
   gui:
     titles:
-      warp-title: "&0&l Warp Tabelaları"
+      warp-title: <black><bold>Warp Tabelaları</bold></black>
     buttons:
       previous:
-        name: "&f&l Önceki Sayfa"
-        description: "&7 [number]. sayfaya geç"
+        name: <white><bold>Önceki Sayfa</bold></white>
+        description: <gray>[number]. sayfaya geç</gray>
       next:
-        name: "&f&l Sonraki Sayfa"
-        description: "&7 [number]. sayfaya geç"
+        name: <white><bold>Sonraki Sayfa</bold></white>
+        description: <gray>[number]. sayfaya geç</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l Rastgele Warp"
-        description: "&7 Hmm, nerede ortaya çıkacağım?"
+        name: <white><bold>Rastgele Warp</bold></white>
+        description: <gray>Hmm, nerede ortaya çıkacağım?</gray>
     tips:
-      click-to-previous: "&e Önceki sayfayı görüntülemek için &7 tıklayın."
-      click-to-next: "&e Sonraki sayfayı görüntülemek için &7 tıklayın."
-      click-to-warp: "&e Işınlanmak için &7 tıklayın."
+      click-to-previous: <yellow>Önceki sayfayı görüntülemek için </yellow><gray>tıklayın.</gray>
+      click-to-next: <yellow>Sonraki sayfayı görüntülemek için </yellow><gray>tıklayın.</gray>
+      click-to-warp: <yellow>Işınlanmak için </yellow><gray>tıklayın.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: warp işaretini değiştir
-  enabled: "&a Warp'ınız artık görünür!"
-  disabled: "&c Warp'ınız artık gizli!"
+  enabled: <green>Warp'ınız artık görünür!</green>
+  disabled: <red>Warp'ınız artık gizli!</red>
   error:
-    no-permission: "&c Buna yetkiniz yok!"
-    generic: "&c Warp değiştirilirken bir hata oluştu."
-    no-warp: "&c Değiştirilecek bir warp'ınız yok!"
+    no-permission: <red>Buna yetkiniz yok!</red>
+    generic: <red>Warp değiştirilirken bir hata oluştu.</red>
+    no-warp: <red>Değiştirilecek bir warp'ınız yok!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -4,56 +4,55 @@ warp:
     description: телепортація на знак варпа гравця
     parameters: "<player name>"
 warps:
-  deactivate: "&c Старий знак варпу деактивовано!"
+  deactivate: <red>Старий знак варпу деактивовано!</red>
   error:
-    does-not-exist: "&c О, чорт! Того викривлення більше не існує!"
-    no-permission: "&c Ви не маєте на це дозволу!"
-    no-remove: "&c Ви не можете видалити цей знак!"
-    no-warps-yet: "&c Ще немає доступних варпів"
-    not-enough-level: "&c Рівень вашого острова недостатньо високий!"
-    not-on-island: "&c Для цього ви повинні бути на своєму острові!"
-    not-safe: "&c Ця варп небезпечна!"
-    your-level-is: "&c Рівень вашого острова становить лише [level] і має бути вищим
-      за [required]. Виконайте команду рівня."
-    not-correct-rank: "&c Ви не маєте належного рангу, щоб встановити варп!"
+    does-not-exist: <red>О, чорт! Того викривлення більше не існує!</red>
+    no-permission: <red>Ви не маєте на це дозволу!</red>
+    no-remove: <red>Ви не можете видалити цей знак!</red>
+    no-warps-yet: <red>Ще немає доступних варпів</red>
+    not-enough-level: <red>Рівень вашого острова недостатньо високий!</red>
+    not-on-island: <red>Для цього ви повинні бути на своєму острові!</red>
+    not-safe: <red>Ця варп небезпечна!</red>
+    your-level-is: <red>Рівень вашого острова становить лише [level] і має бути вищим за [required]. Виконайте команду рівня.</red>
+    not-correct-rank: <red>Ви не маєте належного рангу, щоб встановити варп!</red>
   help:
     description: відкрити панель варпів
-  player-warped: "&2 [name] телепортовано до вашого знака варпу [gamemode]!"
-  sign-removed: "&c Знак варпу видалено!"
-  success: "&a Успіх!"
-  warpTip: "&6 Розмістіть знак варпу з [text] угорі"
-  warpToPlayersSign: "&6 Телепортація на знак [player]."
+  player-warped: <dark_green>[name] телепортовано до вашого знака варпу [gamemode]!</dark_green>
+  sign-removed: <red>Знак варпу видалено!</red>
+  success: <green>Успіх!</green>
+  warpTip: <gold>Розмістіть знак варпу з [text] угорі</gold>
+  warpToPlayersSign: <gold>Телепортація на знак [player].</gold>
   gui:
     titles:
-      warp-title: "&0&l Знаки варпів"
+      warp-title: <black><bold>Знаки варпів</bold></black>
     buttons:
       previous:
-        name: "&f&l Попередня сторінка"
-        description: "&7 Перейти на сторінку [number]."
+        name: <white><bold>Попередня сторінка</bold></white>
+        description: <gray>Перейти на сторінку [number].</gray>
       next:
-        name: "&f&l Наступна сторінка"
-        description: "&7 Перейти на сторінку [number]."
+        name: <white><bold>Наступна сторінка</bold></white>
+        description: <gray>Перейти на сторінку [number].</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l Випадковий варп"
-        description: "&7 Хм, а де я з'явлюся?"
+        name: <white><bold>Випадковий варп</bold></white>
+        description: <gray>Хм, а де я з'явлюся?</gray>
     tips:
-      click-to-previous: "&e Натисніть &7, щоб переглянути попередню сторінку."
-      click-to-next: "&e Натисніть &7, щоб переглянути наступну сторінку."
-      click-to-warp: "&e Натисніть &7, щоб деформувати."
+      click-to-previous: <yellow>Натисніть </yellow><gray>, щоб переглянути попередню сторінку.</gray>
+      click-to-next: <yellow>Натисніть </yellow><gray>, щоб переглянути наступну сторінку.</gray>
+      click-to-warp: <yellow>Натисніть </yellow><gray>, щоб деформувати.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: перемкнути знак варпу
-  enabled: "&a Ваш варп тепер видимий!"
-  disabled: "&c Ваш варп тепер прихований!"
+  enabled: <green>Ваш варп тепер видимий!</green>
+  disabled: <red>Ваш варп тепер прихований!</red>
   error:
-    no-permission: "&c Ви не маєте на це дозволу!"
-    generic: "&c Сталася помилка під час перемикання варпу."
-    no-warp: "&c У вас немає варпу для перемикання!"
+    no-permission: <red>Ви не маєте на це дозволу!</red>
+    generic: <red>Сталася помилка під час перемикання варпу.</red>
+    no-warp: <red>У вас немає варпу для перемикання!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -4,56 +4,55 @@ warp:
     description: đi đến điểm dịch chuyển của người chơi
     parameters: "<tên người chơi>"
 warps:
-  deactivate: "&c Bảng cũ đã vô hiệu hóa!"
+  deactivate: <red>Bảng cũ đã vô hiệu hóa!</red>
   error:
-    does-not-exist: "&c Uầy! Điểm dịch chuyển đó không tồn tại!"
-    no-permission: "&c Bạn không có quyền làm điều đó!"
-    no-remove: "&c Bạn không thể xóa bảng đó!"
-    no-warps-yet: "&c Chưa có điểm dịch chuyển nào"
-    not-enough-level: "&c Cấp đảo của bạn không đủ cao!"
-    not-on-island: "&c Bạn phải ở đảo của bạn để làm điều đó!"
-    not-safe: "&c Điểm dịch chuyển không an toàn!"
-    your-level-is: "&c Cấp đảo của bạn là [level] và phải cao hơn [required].
-      Hãy dùng lệnh xem cấp đảo."
-    not-correct-rank: "&c Bạn không có cấp bậc phù hợp để đặt điểm dịch chuyển!"
+    does-not-exist: <red>Uầy! Điểm dịch chuyển đó không tồn tại!</red>
+    no-permission: <red>Bạn không có quyền làm điều đó!</red>
+    no-remove: <red>Bạn không thể xóa bảng đó!</red>
+    no-warps-yet: <red>Chưa có điểm dịch chuyển nào</red>
+    not-enough-level: <red>Cấp đảo của bạn không đủ cao!</red>
+    not-on-island: <red>Bạn phải ở đảo của bạn để làm điều đó!</red>
+    not-safe: <red>Điểm dịch chuyển không an toàn!</red>
+    your-level-is: <red>Cấp đảo của bạn là [level] và phải cao hơn [required]. Hãy dùng lệnh xem cấp đảo.</red>
+    not-correct-rank: <red>Bạn không có cấp bậc phù hợp để đặt điểm dịch chuyển!</red>
   help:
     description: mở bảng dịch chuyển
-  player-warped: "&2 [name] đã vào điểm dịch chuyển [gamemode] của bạn!"
-  sign-removed: "&c Đã xóa bảng dịch chuyển!"
-  success: "&a Thành công!"
-  warpTip: "&6 Đặt bảng với dòng chữ [text] ở dòng đầu tiên"
-  warpToPlayersSign: "&6 Đang dịch chuyển đến chỗ của [player]"
+  player-warped: <dark_green>[name] đã vào điểm dịch chuyển [gamemode] của bạn!</dark_green>
+  sign-removed: <red>Đã xóa bảng dịch chuyển!</red>
+  success: <green>Thành công!</green>
+  warpTip: <gold>Đặt bảng với dòng chữ [text] ở dòng đầu tiên</gold>
+  warpToPlayersSign: <gold>Đang dịch chuyển đến chỗ của [player]</gold>
   gui:
     titles:
-      warp-title: "&0&l Bảng Dịch Chuyển"
+      warp-title: <black><bold>Bảng Dịch Chuyển</bold></black>
     buttons:
       previous:
-        name: "&f&l Trang Trước"
-        description: "&7 Chuyển sang trang [number]"
+        name: <white><bold>Trang Trước</bold></white>
+        description: <gray>Chuyển sang trang [number]</gray>
       next:
-        name: "&f&l Trang Tiếp"
-        description: "&7 Chuyển sang trang [number]"
+        name: <white><bold>Trang Tiếp</bold></white>
+        description: <gray>Chuyển sang trang [number]</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l Dịch Chuyển Ngẫu Nhiên"
-        description: "&7 Hmm, tôi sẽ xuất hiện ở đâu nhỉ?"
+        name: <white><bold>Dịch Chuyển Ngẫu Nhiên</bold></white>
+        description: <gray>Hmm, tôi sẽ xuất hiện ở đâu nhỉ?</gray>
     tips:
-      click-to-previous: "&e Nhấp &7 để xem trang trước."
-      click-to-next: "&e Nhấp &7 để xem trang tiếp theo."
-      click-to-warp: "&e Nhấp &7 để dịch chuyển."
+      click-to-previous: <yellow>Nhấp </yellow><gray>để xem trang trước.</gray>
+      click-to-next: <yellow>Nhấp </yellow><gray>để xem trang tiếp theo.</gray>
+      click-to-warp: <yellow>Nhấp </yellow><gray>để dịch chuyển.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: chuyển đổi bảng dịch chuyển
-  enabled: "&a Điểm dịch chuyển của bạn hiện đã hiển thị!"
-  disabled: "&c Điểm dịch chuyển của bạn hiện đã ẩn!"
+  enabled: <green>Điểm dịch chuyển của bạn hiện đã hiển thị!</green>
+  disabled: <red>Điểm dịch chuyển của bạn hiện đã ẩn!</red>
   error:
-    no-permission: "&c Bạn không có quyền làm điều đó!"
-    generic: "&c Đã xảy ra lỗi khi chuyển đổi điểm dịch chuyển của bạn."
-    no-warp: "&c Bạn không có điểm dịch chuyển nào để chuyển đổi!"
+    no-permission: <red>Bạn không có quyền làm điều đó!</red>
+    generic: <red>Đã xảy ra lỗi khi chuyển đổi điểm dịch chuyển của bạn.</red>
+    no-warp: <red>Bạn không có điểm dịch chuyển nào để chuyển đổi!</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -4,55 +4,55 @@ warp:
     description: 传送至对应玩家的坐标告示牌
     parameters: "<player name>"
 warps:
-  deactivate: "&c检测到不活跃的坐标告示牌!"
+  deactivate: <red>检测到不活跃的坐标告示牌!</red>
   error:
-    does-not-exist: "&c啊哦! 那个传送点已经不存在了!"
-    no-permission: "&c你没有权限做这件事!"
-    no-remove: "&c你不能移除该告示牌!"
-    no-warps-yet: "&c尚无可用传送点."
-    not-enough-level: "&c你空岛的等级还不够高!"
-    not-on-island: "&c你必须在自己的空岛上做这件事!"
-    not-safe: "&c该传送点不安全!"
-    your-level-is: "&c你空岛的等级只有[level], 但必须高于[required]. 使用/is level查看等级."
-    not-correct-rank: "&c你在团队中的地位不足以让你设立传送点!"
+    does-not-exist: <red>啊哦! 那个传送点已经不存在了!</red>
+    no-permission: <red>你没有权限做这件事!</red>
+    no-remove: <red>你不能移除该告示牌!</red>
+    no-warps-yet: <red>尚无可用传送点.</red>
+    not-enough-level: <red>你空岛的等级还不够高!</red>
+    not-on-island: <red>你必须在自己的空岛上做这件事!</red>
+    not-safe: <red>该传送点不安全!</red>
+    your-level-is: <red>你空岛的等级只有[level], 但必须高于[required]. 使用/is level查看等级.</red>
+    not-correct-rank: <red>你在团队中的地位不足以让你设立传送点!</red>
   help:
     description: 打开传送点面板
-  player-warped: "&2 [name]传送到了你[gamemode]的坐标告示牌!"
-  sign-removed: "&c坐标告示牌已移除!"
-  success: "&a成功!"
-  warpTip: "&6放置一个顶部为[text]的坐标告示牌"
-  warpToPlayersSign: "&6正在传送至[player]的坐标告示牌"
+  player-warped: <dark_green>[name]传送到了你[gamemode]的坐标告示牌!</dark_green>
+  sign-removed: <red>坐标告示牌已移除!</red>
+  success: <green>成功!</green>
+  warpTip: <gold>放置一个顶部为[text]的坐标告示牌</gold>
+  warpToPlayersSign: <gold>正在传送至[player]的坐标告示牌</gold>
   gui:
     titles:
-      warp-title: "&0&l坐标告示牌"
+      warp-title: <black><bold>坐标告示牌</bold></black>
     buttons:
       previous:
-        name: "&f&l上一页"
-        description: "&7跳转到第[number]页"
+        name: <white><bold>上一页</bold></white>
+        description: <gray>跳转到第[number]页</gray>
       next:
-        name: "&f&l下一页"
-        description: "&7跳转到第[number]页"
+        name: <white><bold>下一页</bold></white>
+        description: <gray>跳转到第[number]页</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l随机传送"
-        description: "&7嗯...我会出现在哪里?"
+        name: <white><bold>随机传送</bold></white>
+        description: <gray>嗯...我会出现在哪里?</gray>
     tips:
-      click-to-previous: "&e点击&7 查看上一页."
-      click-to-next: "&e点击&7 查看下一页."
-      click-to-warp: "&e点击&7 进行传送."
+      click-to-previous: <yellow>点击</yellow><gray>查看上一页.</gray>
+      click-to-next: <yellow>点击</yellow><gray>查看下一页.</gray>
+      click-to-warp: <yellow>点击</yellow><gray>进行传送.</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: 切换扭曲符号
-  enabled: "&a 你的扭曲现在可见了！"
-  disabled: "&c 你的扭曲现已隐藏！"
+  enabled: <green>你的扭曲现在可见了！</green>
+  disabled: <red>你的扭曲现已隐藏！</red>
   error:
-    no-permission: "&c您没有权限这么做！"
-    generic: "&c 切换扭曲时发生错误。"
-    no-warp: "&c 您没有可​​切换的扭曲！"
+    no-permission: <red>您没有权限这么做！</red>
+    generic: <red>切换扭曲时发生错误。</red>
+    no-warp: <red>您没有可​​切换的扭曲！</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/zh-HK.yml
+++ b/src/main/resources/locales/zh-HK.yml
@@ -4,55 +4,55 @@ warp:
     description: 傳送到該玩家的傳送木牌處
     parameters: "<玩家名稱>"
 warps:
-  deactivate: "&c 舊傳送牌已停用！"
+  deactivate: <red>舊傳送牌已停用！</red>
   error:
-    does-not-exist: "&c 哦不！嗰個傳送點已經唔存在喇！"
-    no-permission: "&c 你冇權限咁做！"
-    no-remove: "&c 你唔可以移除嗰塊牌！"
-    no-warps-yet: "&c 暫時冇可用傳送點"
-    not-enough-level: "&c 你嘅島嶼等級唔夠高！"
-    not-on-island: "&c 你要喺自己嘅島嶼上面先可以咁做！"
-    not-safe: "&c 目標傳送點唔安全！"
-    your-level-is: "&c 你嘅島嶼現在係 [level] 級，需要 [required] 級。試下島嶼等級命令喇。"
-    not-correct-rank: "&c 你嘅島嶼成員等級唔足以設置傳送點！"
+    does-not-exist: <red>哦不！嗰個傳送點已經唔存在喇！</red>
+    no-permission: <red>你冇權限咁做！</red>
+    no-remove: <red>你唔可以移除嗰塊牌！</red>
+    no-warps-yet: <red>暫時冇可用傳送點</red>
+    not-enough-level: <red>你嘅島嶼等級唔夠高！</red>
+    not-on-island: <red>你要喺自己嘅島嶼上面先可以咁做！</red>
+    not-safe: <red>目標傳送點唔安全！</red>
+    your-level-is: <red>你嘅島嶼現在係 [level] 級，需要 [required] 級。試下島嶼等級命令喇。</red>
+    not-correct-rank: <red>你嘅島嶼成員等級唔足以設置傳送點！</red>
   help:
     description: 打開傳送面板
-  player-warped: "&2 [name] 傳送到咗你嘅 [gamemode] 傳送牌！"
-  sign-removed: "&c 傳送牌已移除！"
-  success: "&a 成功！"
-  warpTip: "&6 放個牌第一行寫 [text]"
-  warpToPlayersSign: "&6 正在傳送到 [player] 嘅牌"
+  player-warped: <dark_green>[name] 傳送到咗你嘅 [gamemode] 傳送牌！</dark_green>
+  sign-removed: <red>傳送牌已移除！</red>
+  success: <green>成功！</green>
+  warpTip: <gold>放個牌第一行寫 [text]</gold>
+  warpToPlayersSign: <gold>正在傳送到 [player] 嘅牌</gold>
   gui:
     titles:
-      warp-title: "&0&l 傳送告示牌"
+      warp-title: <black><bold>傳送告示牌</bold></black>
     buttons:
       previous:
-        name: "&f&l 上一頁"
-        description: "&7 切換到第 [number] 頁"
+        name: <white><bold>上一頁</bold></white>
+        description: <gray>切換到第 [number] 頁</gray>
       next:
-        name: "&f&l 下一頁"
-        description: "&7 切換到第 [number] 頁"
+        name: <white><bold>下一頁</bold></white>
+        description: <gray>切換到第 [number] 頁</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l 隨機傳送"
-        description: "&7 嗯...我會出現喺邊度？"
+        name: <white><bold>隨機傳送</bold></white>
+        description: <gray>嗯...我會出現喺邊度？</gray>
     tips:
-      click-to-previous: "&e 點擊 &7 查看上一頁。"
-      click-to-next: "&e 點擊 &7 查看下一頁。"
-      click-to-warp: "&e 點擊 &7 進行傳送。"
+      click-to-previous: <yellow>點擊 </yellow><gray>查看上一頁。</gray>
+      click-to-next: <yellow>點擊 </yellow><gray>查看下一頁。</gray>
+      click-to-warp: <yellow>點擊 </yellow><gray>進行傳送。</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: 切換傳送符號
-  enabled: "&a 你嘅傳送點依家可見咗！"
-  disabled: "&c 你嘅傳送點依家隱藏咗！"
+  enabled: <green>你嘅傳送點依家可見咗！</green>
+  disabled: <red>你嘅傳送點依家隱藏咗！</red>
   error:
-    no-permission: "&c 你冇權限咁做！"
-    generic: "&c 切換傳送點時發生錯誤。"
-    no-warp: "&c 你冇可切換嘅傳送點！"
+    no-permission: <red>你冇權限咁做！</red>
+    generic: <red>切換傳送點時發生錯誤。</red>
+    no-warp: <red>你冇可切換嘅傳送點！</red>
 protection:
   flags:
     PLACE_WARP:

--- a/src/main/resources/locales/zh-TW.yml
+++ b/src/main/resources/locales/zh-TW.yml
@@ -4,55 +4,55 @@ warp:
     description: 傳送到該玩家的傳送木牌處
     parameters: "<玩家名稱>"
 warps:
-  deactivate: "&c 舊傳送牌已停用！"
+  deactivate: <red>舊傳送牌已停用！</red>
   error:
-    does-not-exist: "&c 哦不！那個傳送點已經沒了！"
-    no-permission: "&c 你沒有權限這樣做！"
-    no-remove: "&c 你拿不掉那個牌子的！"
-    no-warps-yet: "&c 暫無可用傳送點"
-    not-enough-level: "&c 你的島嶼等級不夠高！"
-    not-on-island: "&c 你得在自己的島嶼上操作！"
-    not-safe: "&c 目標傳送點不安全！"
-    your-level-is: "&c 你的島嶼現在 [level] 級，需要 [required] 級。試試島嶼等級命令吧。"
-    not-correct-rank: "&c 你的島嶼成員等級不足以設置傳送點！"
+    does-not-exist: <red>哦不！那個傳送點已經沒了！</red>
+    no-permission: <red>你沒有權限這樣做！</red>
+    no-remove: <red>你拿不掉那個牌子的！</red>
+    no-warps-yet: <red>暫無可用傳送點</red>
+    not-enough-level: <red>你的島嶼等級不夠高！</red>
+    not-on-island: <red>你得在自己的島嶼上操作！</red>
+    not-safe: <red>目標傳送點不安全！</red>
+    your-level-is: <red>你的島嶼現在 [level] 級，需要 [required] 級。試試島嶼等級命令吧。</red>
+    not-correct-rank: <red>你的島嶼成員等級不足以設置傳送點！</red>
   help:
     description: 打開傳送面板
-  player-warped: "&2 [name] 傳送到了你的 [gamemode] 傳送牌！"
-  sign-removed: "&c 拆掉傳送牌了！"
-  success: "&a 成功！"
-  warpTip: "&6 放個牌子第一行寫 [text]"
-  warpToPlayersSign: "&6 正傳送到 [player] 的牌子"
+  player-warped: <dark_green>[name] 傳送到了你的 [gamemode] 傳送牌！</dark_green>
+  sign-removed: <red>拆掉傳送牌了！</red>
+  success: <green>成功！</green>
+  warpTip: <gold>放個牌子第一行寫 [text]</gold>
+  warpToPlayersSign: <gold>正傳送到 [player] 的牌子</gold>
   gui:
     titles:
-      warp-title: "&0&l 傳送告示牌"
+      warp-title: <black><bold>傳送告示牌</bold></black>
     buttons:
       previous:
-        name: "&f&l 上一頁"
-        description: "&7 切換到第 [number] 頁"
+        name: <white><bold>上一頁</bold></white>
+        description: <gray>切換到第 [number] 頁</gray>
       next:
-        name: "&f&l 下一頁"
-        description: "&7 切換到第 [number] 頁"
+        name: <white><bold>下一頁</bold></white>
+        description: <gray>切換到第 [number] 頁</gray>
       warp:
-        name: "&f&l [name]"
+        name: <white><bold>[name]</bold></white>
         description: "[sign_text]"
       random:
-        name: "&f&l 隨機傳送"
-        description: "&7 嗯...我會出現在哪裡？"
+        name: <white><bold>隨機傳送</bold></white>
+        description: <gray>嗯...我會出現在哪裡？</gray>
     tips:
-      click-to-previous: "&e 點擊 &7 查看上一頁。"
-      click-to-next: "&e 點擊 &7 查看下一頁。"
-      click-to-warp: "&e 點擊 &7 進行傳送。"
+      click-to-previous: <yellow>點擊 </yellow><gray>查看上一頁。</gray>
+      click-to-next: <yellow>點擊 </yellow><gray>查看下一頁。</gray>
+      click-to-warp: <yellow>點擊 </yellow><gray>進行傳送。</gray>
   conversations:
-    prefix: "&l&6 [BentoBox]: &r"
+    prefix: '<gold><bold>[BentoBox]: </bold></gold><reset>'
 togglewarp:
   help:
     description: 切換傳送符號
-  enabled: "&a 你的傳送點現在可見了！"
-  disabled: "&c 你的傳送點現已隱藏！"
+  enabled: <green>你的傳送點現在可見了！</green>
+  disabled: <red>你的傳送點現已隱藏！</red>
   error:
-    no-permission: "&c 你沒有權限這樣做！"
-    generic: "&c 切換傳送點時發生錯誤。"
-    no-warp: "&c 你沒有可切換的傳送點！"
+    no-permission: <red>你沒有權限這樣做！</red>
+    generic: <red>切換傳送點時發生錯誤。</red>
+    no-warp: <red>你沒有可切換的傳送點！</red>
 protection:
   flags:
     PLACE_WARP:


### PR DESCRIPTION
Updated Russian localization for warp features, improving clarity and consistency in messages. Additionally, migrated all 23 locale files from legacy `&` color codes to MiniMessage formatting for consistency across the addon. #155

## Changes Made

- **Russian locale (`ru.yml`)**: Reworded strings for warp commands, errors, GUI labels, tips, and protection flag descriptions for improved clarity.
- **All other locales**: Converted legacy `&` color codes (e.g., `&c`, `&a`, `&6`) to MiniMessage tags (e.g., `<red>text</red>`, `<green>text</green>`, `<gold>text</gold>`) across all 23 locale files (cs, de, en-US, es, fr, hr, hu, id, it, ja, ko, lv, nl, pl, pt-BR, pt, ro, tr, uk, vi, zh-CN, zh-HK, zh-TW).
- Combined format+color codes are correctly converted (e.g., `&f&l text` → `<white><bold>text</bold></white>`).
- The prefix reset pattern `&l&6 [BentoBox]: &r` is converted to `<gold><bold>[BentoBox]: </bold></gold><reset>` consistently across all locales.