### PR TITLE
Add MC 26.1.2 to Modrinth game-versions

### DIFF
--- a/.github/workflows/modrinth-publish.yml
+++ b/.github/workflows/modrinth-publish.yml
@@ -89,6 +89,7 @@ jobs:
             1.21.11
             26.1
             26.1.1
+            26.1.2
 
           # Path to the built JAR — Maven produces Warps-<version>.jar in target/
           # Note: glob patterns are not supported; use the release tag directly.


### PR DESCRIPTION
Adds Minecraft `26.1.2` to the `game-versions` list in the Modrinth publish workflow, keeping the supported-versions tags current (the list already had 26.1 and 26.1.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)