### PR TITLE
Notify the sign owner when a warp falls back to the sign block

### DIFF
--- a/src/main/java/world/bentobox/warps/managers/WarpSignsManager.java
+++ b/src/main/java/world/bentobox/warps/managers/WarpSignsManager.java
@@ -384,9 +384,10 @@ public class WarpSignsManager {
     }
 
     /**
-     * Warps a player to a spot in front of a sign.
+     * Warps a player to a spot in front of a sign, or to the sign block itself when no
+     * safe spot in front exists.
      * @param user - user who is warping
-     * @param inFront - location in front of sign - previously checked for safety
+     * @param inFront - warp destination - previously checked for safety
      * @param signOwner - warp sign owner
      * @param directionFacing - direction that sign is facing
      * @param pvp - true if this location allowed PVP
@@ -475,9 +476,10 @@ public class WarpSignsManager {
         }
         // Find out which direction the warp is facing
         Block b = warpSpot.getBlock();
+        BlockFace directionFacing;
         if (Tag.WALL_SIGNS.isTagged(b.getType())) {
             org.bukkit.block.data.type.WallSign s = (org.bukkit.block.data.type.WallSign) b.getBlockData();
-            BlockFace directionFacing = s.getFacing();
+            directionFacing = s.getFacing();
             Location inFront = b.getRelative(directionFacing).getLocation();
             Location oneDown = b.getRelative(directionFacing).getRelative(BlockFace.DOWN).getLocation();
             if ((plugin.getIslands().isSafeLocation(inFront))) {
@@ -489,6 +491,7 @@ public class WarpSignsManager {
                 return;
             }
         } else if (Tag.ALL_HANGING_SIGNS.isTagged(b.getType())) {
+            directionFacing = BlockFace.DOWN;
             Location below = b.getRelative(BlockFace.DOWN).getRelative(BlockFace.DOWN).getLocation();
             if ((addon.getIslands().isSafeLocation(below))) {
                 warpPlayer(user, below, owner, BlockFace.DOWN, pvp);
@@ -496,7 +499,7 @@ public class WarpSignsManager {
             }
         } else if (Tag.STANDING_SIGNS.isTagged(b.getType())) {
             org.bukkit.block.data.type.Sign s = (org.bukkit.block.data.type.Sign) b.getBlockData();
-            BlockFace directionFacing = s.getRotation();
+            directionFacing = s.getRotation();
             Location inFront = b.getRelative(directionFacing).getLocation();
             if ((addon.getIslands().isSafeLocation(inFront))) {
                 warpPlayer(user, inFront, owner, directionFacing, pvp);
@@ -511,15 +514,10 @@ public class WarpSignsManager {
         if (!(plugin.getIslands().isSafeLocation(warpSpot))) {
             user.sendMessage("warps.error.not-safe");
         } else {
-            final Location actualWarp = new Location(warpSpot.getWorld(), warpSpot.getBlockX() + 0.5D, warpSpot.getBlockY(),
-                    warpSpot.getBlockZ() + 0.5D);
-            if (pvp) {
-                user.sendMessage("protection.flags.PVP_OVERWORLD.enabled");
-                user.getWorld().playSound(Objects.requireNonNull(user.getLocation()), Sound.ENTITY_ARROW_HIT, 1F, 1F);
-            } else {
-                user.getWorld().playSound(Objects.requireNonNull(user.getLocation()), Sound.ENTITY_BAT_TAKEOFF, 1F, 1F);
-            }
-            Util.teleportAsync(user.getPlayer(), actualWarp, TeleportCause.COMMAND);
+            // Fall back to the sign's own block, but through the same path as a normal
+            // warp so that the initiate event fires, vanished players stay hidden, and
+            // the sign owner is told that someone warped to them
+            warpPlayer(user, warpSpot, owner, directionFacing, pvp);
         }
     }
 


### PR DESCRIPTION
## What

`warpPlayer(world, user, owner)` has two teleport paths:

- **Normal**: when the spot in front of the sign passes `isSafeLocation`, the visitor is warped there via the private `warpPlayer(...)`, which fires `WarpInitiateEvent`, respects vanished players, plays the sound after a successful teleport, and sends the sign owner `warps.player-warped`.
- **Fallback**: when no safe spot in front exists, the visitor was teleported directly onto the sign's own block — with no event, no vanish check, and **no owner notification**.

This PR routes the fallback through the same completion path as a normal warp, so behavior is identical wherever the visitor lands. The sign's facing is now also used for the arrival yaw in the fallback, matching normal warps.

## Why

Server admins noticed that island owners get "X warped to your warp sign!" in AOneBlock but never in ChunkBlock. The cause is geometry: a ChunkBlock island starts as a single chunk, so warp signs typically sit at the platform edge with void in front — `isSafeLocation(inFront)` fails and the silent fallback always runs. The same silent path can trigger in any gamemode whenever the block in front of a sign is unsafe.

## Testing

Full suite passes (79 tests). The sign-specific branches aren't reachable in unit tests because MockBukkit doesn't populate the sign `Tag` constants, so this was verified by inspection; a manual test on a ChunkBlock island (warp sign at the platform edge, void in front) is the reproduction case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7xSdVPS5vRu6wqf6XshRq